### PR TITLE
refactor: extract reusable recipe components and add product detail i18n

### DIFF
--- a/src/app/categories/[categoryId]/page.tsx
+++ b/src/app/categories/[categoryId]/page.tsx
@@ -9,6 +9,7 @@ import { SharedHeader } from "@/components/shared-header";
 import { SubcategoryView } from "@/components/subcategory-view";
 import type { SubcategoriesState } from "@/components/subcategory-view";
 import { CartProvider } from "@/contexts/cart-context";
+import { useTranslations } from "@/contexts/country-context";
 import { usePageTitle } from "@/hooks/use-page-title";
 import type { CategoryItem, SubcategoriesApiResponse } from "@/lib/category-types";
 import { TOKEN_EXPIRED_REDIRECT } from "@/lib/constants";
@@ -23,6 +24,8 @@ export default function CategorySubcategoriesPage() {
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const dismissToast = useCallback(() => setToastMessage(null), []);
 
+  const t = useTranslations();
+  const { categoryFallbackTitle, subcategoriesLoadError } = t;
   const categoryName = state.status === "success" ? state.title : undefined;
   usePageTitle(categoryName);
 
@@ -44,7 +47,7 @@ export default function CategorySubcategoriesPage() {
         }
         setState({
           status: "success",
-          title: data.title ?? "Categorie",
+          title: data.title ?? categoryFallbackTitle,
           subcategories: Array.isArray(data.subcategories) ? data.subcategories : [],
         });
       })
@@ -52,12 +55,12 @@ export default function CategorySubcategoriesPage() {
         if (err instanceof DOMException && err.name === "AbortError") return;
         setState({
           status: "error",
-          message: "Kan subcategorieën niet laden.",
+          message: subcategoriesLoadError,
         });
       });
 
     return () => controller.abort();
-  }, [categoryId, retryCount]);
+  }, [categoryId, retryCount, categoryFallbackTitle, subcategoriesLoadError]);
 
   const handleBack = useCallback(() => {
     router.push("/");
@@ -77,7 +80,7 @@ export default function CategorySubcategoriesPage() {
     setRetryCount((c) => c + 1);
   }, []);
 
-  const displayName = state.status === "success" ? state.title : "Categorie";
+  const displayName = state.status === "success" ? state.title : t.categoryFallbackTitle;
 
   return (
     <CartProvider showToast={setToastMessage}>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { usePageTitle } from "@/hooks/use-page-title";
+import { useTranslations } from "@/contexts/country-context";
 
 export default function Error({
   error,
@@ -10,16 +11,17 @@ export default function Error({
   reset: () => void;
 }) {
   usePageTitle();
+  const t = useTranslations();
 
   return (
     <div className="flex min-h-full flex-1 flex-col items-center justify-center p-8 text-center">
-      <h2 className="text-foreground text-2xl font-bold">Er is iets misgegaan</h2>
-      <p className="mt-2 text-gray-500">{error.message || "Een onverwachte fout is opgetreden."}</p>
+      <h2 className="text-foreground text-2xl font-bold">{t.errorHeading}</h2>
+      <p className="mt-2 text-gray-500">{error.message || t.errorUnexpected}</p>
       <button
         onClick={reset}
         className="bg-picnic-red hover:bg-picnic-red-dark mt-6 rounded-full px-6 py-2.5 text-sm font-medium text-white transition-colors"
       >
-        Probeer opnieuw
+        {t.errorRetry}
       </button>
     </div>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -301,7 +301,7 @@ function LoginForm() {
                 htmlFor="auth-token"
                 className="text-foreground mb-1 block text-sm font-medium"
               >
-                Picnic Auth Token
+                {t.authTokenLabel}
               </label>
               <div className="relative">
                 <input
@@ -341,7 +341,7 @@ function LoginForm() {
             disabled={isLoading}
             className="bg-picnic-red hover:bg-picnic-red-dark focus:ring-picnic-red flex w-full items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold text-white transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:opacity-50"
           >
-            {isLoading ? <Spinner /> : showTwoFactor ? t.verifyButton : t.loginButton}
+            {isLoading ? <Spinner ariaLabel={t.loadingAriaLabel} /> : showTwoFactor ? t.verifyButton : t.loginButton}
           </button>
         </form>
 
@@ -449,12 +449,12 @@ function mapErrorMessage(code: string | undefined, t: Translations): string {
 
 // ─── Icons & Loading ─────────────────────────────────────────────────────────
 
-function Spinner() {
+function Spinner({ ariaLabel }: { ariaLabel: string }) {
   return (
     <div
       className="h-5 w-5 animate-spin rounded-full border-2 border-white/30 border-t-white"
       role="status"
-      aria-label="Laden"
+      aria-label={ariaLabel}
     />
   );
 }

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -18,6 +18,7 @@ import { ProductPriceSection } from "@/components/product-price-section";
 import { ProductSlider } from "@/components/product-slider";
 import { SharedHeader } from "@/components/shared-header";
 import { CartProvider, useCart } from "@/contexts/cart-context";
+import { useTranslations } from "@/contexts/country-context";
 import { usePageTitle } from "@/hooks/use-page-title";
 import { TOKEN_EXPIRED_MESSAGE, TOKEN_EXPIRED_REDIRECT } from "@/lib/constants";
 import type { ApiErrorResponse, ProductDetail } from "@/lib/types";
@@ -125,6 +126,7 @@ function NotFoundView() {
 
 function ProductDetailView({ product }: { product: ProductDetail }) {
   const { getQuantity, addProduct, removeProduct } = useCart();
+  const t = useTranslations();
   const cartQuantity = getQuantity(product.id);
 
   const handleSetQuantity = useCallback(
@@ -220,7 +222,7 @@ function ProductDetailView({ product }: { product: ProductDetail }) {
       )}
 
       {/* Similar products slider */}
-      <ProductSlider title="Vergelijkbare producten" products={product.similarProducts} />
+      <ProductSlider title={t.similarProductsTitle} products={product.similarProducts} />
     </div>
   );
 }

--- a/src/app/recipe/[id]/page.tsx
+++ b/src/app/recipe/[id]/page.tsx
@@ -1,21 +1,23 @@
 "use client";
 
-import React, { use, useCallback, useEffect, useState } from "react";
+import { use, useCallback, useEffect, useState } from "react";
 
-import Image from "next/image";
 import Link from "next/link";
 
+import { AllergenBadges } from "@/components/allergen-badges";
+import { NutritionTable } from "@/components/nutrition-table";
+import { RecipeHeroImage } from "@/components/recipe-hero-image";
+import { RecipeIngredientRow } from "@/components/recipe-ingredient-row";
 import { ErrorView } from "@/components/error-view";
 import { LoadingSpinner } from "@/components/loading-spinner";
 import { SharedHeader } from "@/components/shared-header";
 import { CartProvider, useCart } from "@/contexts/cart-context";
 import { useCountryCode, useTranslations } from "@/contexts/country-context";
 import { usePageTitle } from "@/hooks/use-page-title";
-import { buildImageUrl, buildRecipeImageUrl } from "@/lib/image-url";
+import { formatEuroPrice } from "@/lib/format-price";
+import { renderMarkdownBold } from "@/lib/render-markdown-bold";
 import { TOKEN_EXPIRED_REDIRECT } from "@/lib/constants";
-import type { ApiErrorResponse, CountryCode, NutritionRow, RecipeDetail, RecipeIngredient } from "@/lib/types";
-
-const PLACEHOLDER = "/placeholder-product.svg";
+import type { ApiErrorResponse, RecipeDetail } from "@/lib/types";
 
 type PageState =
   | { status: "loading" }
@@ -23,167 +25,6 @@ type PageState =
   | { status: "error"; message: string };
 
 type AddState = "idle" | "adding" | "done";
-
-function formatPrice(cents: number): string {
-  return `€${(cents / 100).toFixed(2).replace(".", ",")}`;
-}
-
-function renderInlineMarkdown(text: string): React.ReactNode {
-  const parts = text.split("**");
-  if (parts.length === 1) return text;
-  return parts.map((part, i) =>
-    i % 2 === 1 ? <strong key={i} className="font-semibold">{part}</strong> : part
-  );
-}
-
-// ─── Nutrition table ──────────────────────────────────────────────────────────
-
-function RecipeNutritionTable({ rows }: { rows: NutritionRow[] }) {
-  if (rows.length === 0) return null;
-  return (
-    <table className="w-full text-sm">
-      <tbody>
-        {rows.map((row, i) => (
-          <tr key={i} className={i % 2 === 0 ? "bg-gray-50" : "bg-white"}>
-            <td
-              className={`py-1.5 text-gray-600 ${row.isCategory ? "pl-3 font-medium" : "pl-6 text-xs text-gray-500"}`}
-            >
-              {row.label}
-            </td>
-            <td className="py-1.5 pr-3 text-right font-medium text-gray-800">{row.value}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-}
-
-// ─── Hero image ───────────────────────────────────────────────────────────────
-
-function HeroImage({ imageId, countryCode, alt }: { imageId: string; countryCode: CountryCode; alt: string }) {
-  const [show, setShow] = useState(true);
-  if (!show) return <div className="aspect-video w-full bg-gray-100" />;
-  return (
-    <div className="relative aspect-video w-full">
-      <Image
-        src={buildRecipeImageUrl(imageId, countryCode)}
-        alt={alt}
-        fill
-        unoptimized
-        className="object-cover"
-        priority
-        onError={() => setShow(false)}
-      />
-    </div>
-  );
-}
-
-// ─── Ingredient row ───────────────────────────────────────────────────────────
-
-/**
- * Scale the "(100 g benötigt)" string from the API by the current portion ratio.
- * Handles integers and decimals; formats back with comma if fractional.
- */
-function scaleNeededText(text: string, portions: number, basePortion: number): string {
-  if (basePortion === 0) return text;
-  const m = /^\((\d+(?:[.,]\d+)?)\s+(.+)\)$/.exec(text);
-  if (!m) return text;
-  const num = parseFloat(m[1].replace(",", "."));
-  const scaled = (num * portions) / basePortion;
-  const scaledStr = Number.isInteger(scaled)
-    ? String(scaled)
-    : scaled.toFixed(1).replace(".", ",");
-  return `(${scaledStr} ${m[2]})`;
-}
-
-function IngredientRow({
-  ingredient,
-  qty,
-  portions,
-  basePortion,
-  checked,
-  onToggle,
-}: {
-  ingredient: RecipeIngredient;
-  qty: number;
-  portions: number;
-  basePortion: number;
-  checked: boolean;
-  onToggle: () => void;
-}) {
-  const countryCode = useCountryCode();
-  const [imgSrc, setImgSrc] = useState(
-    ingredient.imageId ? buildImageUrl(ingredient.imageId, countryCode) : PLACEHOLDER
-  );
-
-  const scaledNeeded = ingredient.recipeQuantityText
-    ? scaleNeededText(ingredient.recipeQuantityText, portions, basePortion)
-    : null;
-
-  const displayPkg = ingredient.recipePackageSize ?? ingredient.unitQuantity;
-  const packageLabel = qty > 1 ? `${qty} × ${displayPkg}` : displayPkg;
-  const subtitle = scaledNeeded ? `${packageLabel} ${scaledNeeded}` : packageLabel;
-
-  // Effective unit price: use the best matching bundle tier when qty qualifies
-  const bundleTier = ingredient.priceRanges
-    ?.filter((t) => t.quantity <= qty)
-    .at(-1);
-  const effectiveUnitPrice = bundleTier ? bundleTier.pricePerUnit : ingredient.displayPrice;
-  const totalPrice = effectiveUnitPrice * qty;
-
-  // Crossed-out price: only shown when there is a genuine saving (strikethrough > effective).
-  const rawStrikethrough =
-    bundleTier
-      ? ingredient.displayPrice * qty
-      : ingredient.originalPrice !== null
-        ? ingredient.originalPrice * qty
-        : null;
-  const strikethroughTotal = rawStrikethrough !== null && rawStrikethrough > totalPrice ? rawStrikethrough : null;
-
-  const onSale = strikethroughTotal !== null;
-
-  return (
-    <div className={`flex items-center gap-3 py-3 ${onSale ? "-mx-4 rounded-lg bg-yellow-50 px-4" : ""}`}>
-      <button
-        type="button"
-        role="checkbox"
-        aria-checked={checked}
-        onClick={onToggle}
-        className={`shrink-0 h-5 w-5 rounded border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-picnic-red focus:ring-offset-1 flex items-center justify-center ${
-          checked
-            ? "border-picnic-red bg-picnic-red"
-            : "border-gray-300 bg-white"
-        }`}
-      >
-        {checked && (
-          <svg className="h-3 w-3 text-white" viewBox="0 0 12 12" fill="none">
-            <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        )}
-      </button>
-      <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-lg bg-gray-50">
-        <Image
-          src={imgSrc}
-          alt={ingredient.name}
-          fill
-          unoptimized
-          className={`object-contain p-1 transition-opacity ${checked ? "" : "opacity-40"}`}
-          onError={() => { if (imgSrc !== PLACEHOLDER) setImgSrc(PLACEHOLDER); }}
-        />
-      </div>
-      <div className={`min-w-0 flex-1 transition-opacity ${checked ? "" : "opacity-40"}`}>
-        <p className="text-text-dark truncate text-sm font-medium">{ingredient.name}</p>
-        <p className="text-text-muted text-xs">{subtitle}</p>
-      </div>
-      <div className={`shrink-0 text-right transition-opacity ${checked ? "" : "opacity-40"}`}>
-        <p className={`text-sm font-medium ${onSale ? "text-amber-600" : "text-text-dark"}`}>{formatPrice(totalPrice)}</p>
-        {onSale && (
-          <p className="text-xs text-gray-400 line-through">{formatPrice(strikethroughTotal)}</p>
-        )}
-      </div>
-    </div>
-  );
-}
 
 // ─── Inner page (needs cart context) ─────────────────────────────────────────
 
@@ -327,14 +168,13 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
     const unitPrice = bundleTier ? bundleTier.pricePerUnit : ing.displayPrice;
     return sum + unitPrice * qty;
   }, 0);
-  const pricePerServing = pricePortions > 0 ? formatPrice(Math.round(totalCents / pricePortions)) : null;
+  const pricePerServing = pricePortions > 0 ? formatEuroPrice(Math.round(totalCents / pricePortions)) : null;
 
   const buttonLabel =
     addState === "adding" ? t.recipeAddingToCart
     : addState === "done" ? t.recipeAddedToCart
     : t.recipeAddToCart;
 
-  const { confirmed, mayContain } = recipe.allergens;
 
   return (
     <div className="flex min-h-full flex-1 flex-col">
@@ -351,7 +191,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
         {/* Hero image */}
         <div className="mb-8 overflow-hidden rounded-2xl bg-gray-50">
           {recipe.imageId ? (
-            <HeroImage imageId={recipe.imageId} countryCode={countryCode} alt={recipe.name} />
+            <RecipeHeroImage imageId={recipe.imageId} countryCode={countryCode} alt={recipe.name} />
           ) : (
             <div className="aspect-video w-full bg-gray-100" />
           )}
@@ -385,7 +225,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
               <span className="font-medium text-foreground">{pricePerServing}</span>{" "}
               <span className="text-gray-400">{t.recipePricePerServing}</span>
               <span className="mx-1.5 text-gray-300">·</span>
-              <span className="font-medium text-foreground">{formatPrice(totalCents)}</span>{" "}
+              <span className="font-medium text-foreground">{formatEuroPrice(totalCents)}</span>{" "}
               <span className="text-gray-400">{t.recipePriceTotal}</span>
               {recipe.cookingTimeMinutes !== null && (
                 <>
@@ -426,7 +266,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
                 <h2 className="text-foreground mb-2 text-base font-semibold">{t.recipeIngredients}</h2>
                 <div className="divide-y divide-gray-100 rounded-xl border border-gray-200 bg-white px-4">
                   {mainIngredients.map((ing) => (
-                    <IngredientRow
+                    <RecipeIngredientRow
                       key={ing.id}
                       ingredient={ing}
                       qty={Math.max(1, Math.ceil((ing.quantity * pricePortions) / recipe.portions))}
@@ -449,7 +289,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
                 <h2 className="text-text-muted mb-2 text-sm font-medium">{t.recipeCondiments}</h2>
                 <div className="divide-y divide-gray-100 rounded-xl border border-gray-100 bg-gray-50 px-4">
                   {condiments.map((ing) => (
-                    <IngredientRow
+                    <RecipeIngredientRow
                       key={ing.id}
                       ingredient={ing}
                       qty={Math.max(1, Math.ceil((ing.quantity * pricePortions) / recipe.portions))}
@@ -481,7 +321,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
                       <span className="bg-picnic-red mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white">
                         {i + 1}
                       </span>
-                      <p className="text-text-dark text-sm leading-relaxed">{renderInlineMarkdown(step)}</p>
+                      <p className="text-text-dark text-sm leading-relaxed">{renderMarkdownBold(step)}</p>
                     </li>
                   ))}
                 </ol>
@@ -492,7 +332,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
                 <h2 className="text-foreground mb-2 text-base font-semibold">{t.recipeNutrition}</h2>
                 <p className="text-text-muted mb-2 text-xs">{t.recipePricePerServing}</p>
                 <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
-                  <RecipeNutritionTable rows={recipe.recipeNutritionRows} />
+                  <NutritionTable rows={recipe.recipeNutritionRows} />
                 </div>
               </section>
             )}
@@ -500,38 +340,14 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
         </div>
 
         {/* Allergens */}
-        {(confirmed.length > 0 || mayContain.length > 0) && (
+        {(recipe.allergens.confirmed.length > 0 || recipe.allergens.mayContain.length > 0) && (
           <section className="mb-6 rounded-xl border border-gray-200 bg-white p-4">
-            {confirmed.length > 0 && (
-              <div className={mayContain.length > 0 ? "mb-4" : ""}>
-                <p className="text-text-dark mb-2 text-sm font-semibold">{t.recipeAllergens}</p>
-                <div className="flex flex-wrap gap-1.5">
-                  {confirmed.map((name) => (
-                    <span
-                      key={name}
-                      className="rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800"
-                    >
-                      {name}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-            {mayContain.length > 0 && (
-              <div>
-                <p className="text-text-muted mb-2 text-sm font-medium">{t.recipeMayContain}</p>
-                <div className="flex flex-wrap gap-1.5">
-                  {mayContain.map((name) => (
-                    <span
-                      key={name}
-                      className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600"
-                    >
-                      {name}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
+            <AllergenBadges
+              allergens={recipe.allergens}
+              title=""
+              confirmedLabel={t.recipeAllergens}
+              mayContainLabel={t.recipeMayContain}
+            />
           </section>
         )}
       </main>

--- a/src/components/allergen-badges.tsx
+++ b/src/components/allergen-badges.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "@/contexts/country-context";
 import type { AllergenInfo } from "@/lib/types";
 
 type AllergenBadgesProps = {
@@ -9,10 +12,14 @@ type AllergenBadgesProps = {
 
 export function AllergenBadges({
   allergens,
-  title = "Allergenen",
-  confirmedLabel = "Bevat",
-  mayContainLabel = "Bevat mogelijk",
+  title,
+  confirmedLabel,
+  mayContainLabel,
 }: AllergenBadgesProps) {
+  const t = useTranslations();
+  const resolvedTitle = title ?? t.allergenTitle;
+  const resolvedConfirmedLabel = confirmedLabel ?? t.recipeAllergens;
+  const resolvedMayContainLabel = mayContainLabel ?? t.recipeMayContain;
   const hasConfirmed = allergens.confirmed.length > 0;
   const hasMayContain = allergens.mayContain.length > 0;
 
@@ -20,11 +27,11 @@ export function AllergenBadges({
 
   return (
     <div className="space-y-3">
-      {title && <h2 className="text-foreground text-lg font-semibold">{title}</h2>}
+      {resolvedTitle && <h2 className="text-foreground text-lg font-semibold">{resolvedTitle}</h2>}
 
       {hasConfirmed && (
         <div>
-          <p className="mb-1.5 text-sm font-medium text-gray-600">{confirmedLabel}</p>
+          <p className="mb-1.5 text-sm font-medium text-gray-600">{resolvedConfirmedLabel}</p>
           <div className="flex flex-wrap gap-2">
             {allergens.confirmed.map((badge) => (
               <span
@@ -41,7 +48,7 @@ export function AllergenBadges({
 
       {hasMayContain && (
         <div>
-          <p className="mb-1.5 text-sm font-medium text-gray-500">{mayContainLabel}</p>
+          <p className="mb-1.5 text-sm font-medium text-gray-500">{resolvedMayContainLabel}</p>
           <div className="flex flex-wrap gap-2">
             {allergens.mayContain.map((badge) => (
               <span

--- a/src/components/allergen-badges.tsx
+++ b/src/components/allergen-badges.tsx
@@ -2,9 +2,17 @@ import type { AllergenInfo } from "@/lib/types";
 
 type AllergenBadgesProps = {
   allergens: AllergenInfo;
+  title?: string;
+  confirmedLabel?: string;
+  mayContainLabel?: string;
 };
 
-export function AllergenBadges({ allergens }: AllergenBadgesProps) {
+export function AllergenBadges({
+  allergens,
+  title = "Allergenen",
+  confirmedLabel = "Bevat",
+  mayContainLabel = "Bevat mogelijk",
+}: AllergenBadgesProps) {
   const hasConfirmed = allergens.confirmed.length > 0;
   const hasMayContain = allergens.mayContain.length > 0;
 
@@ -12,21 +20,17 @@ export function AllergenBadges({ allergens }: AllergenBadgesProps) {
 
   return (
     <div className="space-y-3">
-      <h2 className="text-foreground text-lg font-semibold">Allergenen</h2>
+      {title && <h2 className="text-foreground text-lg font-semibold">{title}</h2>}
 
-      {/* Confirmed allergens */}
       {hasConfirmed && (
         <div>
-          <p className="mb-1.5 text-sm font-medium text-gray-600">Bevat</p>
+          <p className="mb-1.5 text-sm font-medium text-gray-600">{confirmedLabel}</p>
           <div className="flex flex-wrap gap-2">
             {allergens.confirmed.map((badge) => (
               <span
                 key={badge.text}
                 className="rounded px-3 py-1 text-xs font-medium"
-                style={{
-                  backgroundColor: badge.backgroundColor,
-                  color: badge.textColor,
-                }}
+                style={{ backgroundColor: badge.backgroundColor, color: badge.textColor }}
               >
                 {badge.text}
               </span>
@@ -35,19 +39,15 @@ export function AllergenBadges({ allergens }: AllergenBadgesProps) {
         </div>
       )}
 
-      {/* May contain allergens */}
       {hasMayContain && (
         <div>
-          <p className="mb-1.5 text-sm font-medium text-gray-500">Bevat mogelijk</p>
+          <p className="mb-1.5 text-sm font-medium text-gray-500">{mayContainLabel}</p>
           <div className="flex flex-wrap gap-2">
             {allergens.mayContain.map((badge) => (
               <span
                 key={badge.text}
                 className="rounded px-3 py-1 text-xs font-medium"
-                style={{
-                  backgroundColor: badge.backgroundColor,
-                  color: badge.textColor,
-                }}
+                style={{ backgroundColor: badge.backgroundColor, color: badge.textColor }}
               >
                 {badge.text}
               </span>

--- a/src/components/product-price-section.tsx
+++ b/src/components/product-price-section.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "@/contexts/country-context";
 import { formatPrice } from "@/lib/format-price";
 import type { BundleOption, ProductPromotion } from "@/lib/types";
 
@@ -83,6 +86,7 @@ type BundleTierGridProps = {
 };
 
 function BundleTierGrid({ bundles, cartQuantity, onSetQuantity }: BundleTierGridProps) {
+  const t = useTranslations();
   const activeTierIndex = findActiveTierIndex(bundles, cartQuantity);
 
   return (
@@ -99,7 +103,7 @@ function BundleTierGrid({ bundles, cartQuantity, onSetQuantity }: BundleTierGrid
               isActive ? "bg-[#d6e6cd] ring-1 ring-[#b0cfb0]" : "bg-gray-100 hover:bg-gray-200"
             }`}
           >
-            <span className="text-xs text-gray-500">Vanaf {bundle.quantity}</span>
+            <span className="text-xs text-gray-500">{t.bundleFromLabel} {bundle.quantity}</span>
             <span
               className={`text-sm font-bold ${
                 isActive ? "text-price-discount" : "text-foreground"
@@ -137,13 +141,15 @@ type PdpStepperProps = {
 };
 
 function PdpStepper({ quantity, maxCount, onIncrement, onDecrement }: PdpStepperProps) {
+  const t = useTranslations();
+
   if (quantity === 0) {
     return (
       <button
         onClick={onIncrement}
         className="border-card-border text-foreground w-full rounded-lg border bg-white py-3 text-center text-sm font-semibold transition-colors hover:bg-gray-50"
       >
-        In mandje
+        {t.addToCartButton}
       </button>
     );
   }
@@ -157,7 +163,7 @@ function PdpStepper({ quantity, maxCount, onIncrement, onDecrement }: PdpStepper
         &minus;
       </button>
       <span className="text-foreground flex-1 text-center text-sm font-semibold">
-        {quantity} in mandje
+        {quantity} {t.inCartLabel}
       </span>
       <button
         onClick={onIncrement}

--- a/src/components/recipe-hero-image.tsx
+++ b/src/components/recipe-hero-image.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+import Image from "next/image";
+
+import { buildRecipeImageUrl } from "@/lib/image-url";
+import type { CountryCode } from "@/lib/types";
+
+type RecipeHeroImageProps = {
+  imageId: string;
+  countryCode: CountryCode;
+  alt: string;
+};
+
+export function RecipeHeroImage({ imageId, countryCode, alt }: RecipeHeroImageProps) {
+  const [show, setShow] = useState(true);
+  if (!show) return <div className="aspect-video w-full bg-gray-100" />;
+  return (
+    <div className="relative aspect-video w-full">
+      <Image
+        src={buildRecipeImageUrl(imageId, countryCode)}
+        alt={alt}
+        fill
+        unoptimized
+        className="object-cover"
+        priority
+        onError={() => setShow(false)}
+      />
+    </div>
+  );
+}

--- a/src/components/recipe-ingredient-row.tsx
+++ b/src/components/recipe-ingredient-row.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+
+import Image from "next/image";
+
+import { useCountryCode } from "@/contexts/country-context";
+import { buildImageUrl } from "@/lib/image-url";
+import { formatEuroPrice } from "@/lib/format-price";
+import type { RecipeIngredient } from "@/lib/types";
+
+const PLACEHOLDER = "/placeholder-product.svg";
+
+function scaleNeededText(text: string, portions: number, basePortion: number): string {
+  if (basePortion === 0) return text;
+  const m = /^\((\d+(?:[.,]\d+)?)\s+(.+)\)$/.exec(text);
+  if (!m) return text;
+  const num = parseFloat(m[1].replace(",", "."));
+  const scaled = (num * portions) / basePortion;
+  const scaledStr = Number.isInteger(scaled)
+    ? String(scaled)
+    : scaled.toFixed(1).replace(".", ",");
+  return `(${scaledStr} ${m[2]})`;
+}
+
+type RecipeIngredientRowProps = {
+  ingredient: RecipeIngredient;
+  qty: number;
+  portions: number;
+  basePortion: number;
+  checked: boolean;
+  onToggle: () => void;
+};
+
+export function RecipeIngredientRow({
+  ingredient,
+  qty,
+  portions,
+  basePortion,
+  checked,
+  onToggle,
+}: RecipeIngredientRowProps) {
+  const countryCode = useCountryCode();
+  const [imgSrc, setImgSrc] = useState(
+    ingredient.imageId ? buildImageUrl(ingredient.imageId, countryCode) : PLACEHOLDER
+  );
+
+  const scaledNeeded = ingredient.recipeQuantityText
+    ? scaleNeededText(ingredient.recipeQuantityText, portions, basePortion)
+    : null;
+
+  const displayPkg = ingredient.recipePackageSize ?? ingredient.unitQuantity;
+  const packageLabel = qty > 1 ? `${qty} × ${displayPkg}` : displayPkg;
+  const subtitle = scaledNeeded ? `${packageLabel} ${scaledNeeded}` : packageLabel;
+
+  const bundleTier = ingredient.priceRanges?.filter((t) => t.quantity <= qty).at(-1);
+  const effectiveUnitPrice = bundleTier ? bundleTier.pricePerUnit : ingredient.displayPrice;
+  const totalPrice = effectiveUnitPrice * qty;
+
+  const rawStrikethrough = bundleTier
+    ? ingredient.displayPrice * qty
+    : ingredient.originalPrice !== null
+      ? ingredient.originalPrice * qty
+      : null;
+  const strikethroughTotal =
+    rawStrikethrough !== null && rawStrikethrough > totalPrice ? rawStrikethrough : null;
+
+  const onSale = strikethroughTotal !== null;
+
+  return (
+    <div className={`flex items-center gap-3 py-3 ${onSale ? "-mx-4 rounded-lg bg-yellow-50 px-4" : ""}`}>
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked={checked}
+        onClick={onToggle}
+        className={`shrink-0 h-5 w-5 rounded border-2 transition-colors focus:outline-none focus:ring-2 focus:ring-picnic-red focus:ring-offset-1 flex items-center justify-center ${
+          checked ? "border-picnic-red bg-picnic-red" : "border-gray-300 bg-white"
+        }`}
+      >
+        {checked && (
+          <svg className="h-3 w-3 text-white" viewBox="0 0 12 12" fill="none">
+            <path
+              d="M2 6l3 3 5-5"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        )}
+      </button>
+      <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-lg bg-gray-50">
+        <Image
+          src={imgSrc}
+          alt={ingredient.name}
+          fill
+          unoptimized
+          className={`object-contain p-1 transition-opacity ${checked ? "" : "opacity-40"}`}
+          onError={() => {
+            if (imgSrc !== PLACEHOLDER) setImgSrc(PLACEHOLDER);
+          }}
+        />
+      </div>
+      <div className={`min-w-0 flex-1 transition-opacity ${checked ? "" : "opacity-40"}`}>
+        <p className="text-text-dark truncate text-sm font-medium">{ingredient.name}</p>
+        <p className="text-text-muted text-xs">{subtitle}</p>
+      </div>
+      <div className={`shrink-0 text-right transition-opacity ${checked ? "" : "opacity-40"}`}>
+        <p className={`text-sm font-medium ${onSale ? "text-amber-600" : "text-text-dark"}`}>
+          {formatEuroPrice(totalPrice)}
+        </p>
+        {onSale && (
+          <p className="text-xs text-gray-400 line-through">{formatEuroPrice(strikethroughTotal)}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/results-view.tsx
+++ b/src/components/results-view.tsx
@@ -27,7 +27,7 @@ export function ResultsView({ query, products, sections }: ResultsViewProps) {
   return (
     <div>
       <p className="mb-4 text-sm text-gray-500">
-        {products.length} {products.length === 1 ? t.resultSingular : t.resultPlural} voor &ldquo;
+        {products.length} {products.length === 1 ? t.resultSingular : t.resultPlural} {t.resultFor} &ldquo;
         {query}
         &rdquo;
       </p>

--- a/src/lib/format-price.ts
+++ b/src/lib/format-price.ts
@@ -7,3 +7,11 @@ import { CENTS_DIVISOR } from "@/lib/types";
 export function formatPrice(cents: number): string {
   return (cents / CENTS_DIVISOR).toFixed(2);
 }
+
+/**
+ * Format a price in cents to a European display string with € symbol.
+ * Uses comma as decimal separator (e.g. 149 → "€1,49").
+ */
+export function formatEuroPrice(cents: number): string {
+  return `€${(cents / CENTS_DIVISOR).toFixed(2).replace(".", ",")}`;
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -102,6 +102,10 @@ const translations = {
 
     // Product card
     addToCartAriaLabel: "Toevoegen aan winkelwagen",
+    addToCartButton: "In mandje",
+    inCartLabel: "in mandje",
+    bundleFromLabel: "Vanaf",
+    similarProductsTitle: "Vergelijkbare producten",
 
     // Category grid
     allCategoriesTitle: "Alle categorieën",
@@ -153,6 +157,24 @@ const translations = {
     // Toast / error view
     dismissAriaLabel: "Sluiten",
     retryButton: "Opnieuw proberen",
+
+    // Generic error page
+    errorHeading: "Er is iets misgegaan",
+    errorUnexpected: "Een onverwachte fout is opgetreden.",
+    errorRetry: "Probeer opnieuw",
+
+    // Category page
+    categoryFallbackTitle: "Categorie",
+    subcategoriesLoadError: "Kan subcategorieën niet laden.",
+
+    // Token login label
+    authTokenLabel: "Picnic Auth-token",
+
+    // Search results count
+    resultFor: "voor",
+
+    // Allergen badges
+    allergenTitle: "Allergenen",
   },
   DE: {
     // Search bar
@@ -255,6 +277,10 @@ const translations = {
 
     // Product card
     addToCartAriaLabel: "Zum Warenkorb hinzufügen",
+    addToCartButton: "In den Warenkorb",
+    inCartLabel: "im Warenkorb",
+    bundleFromLabel: "Ab",
+    similarProductsTitle: "Ähnliche Produkte",
 
     // Category grid
     allCategoriesTitle: "Alle Kategorien",
@@ -306,6 +332,24 @@ const translations = {
     // Toast / error view
     dismissAriaLabel: "Schließen",
     retryButton: "Erneut versuchen",
+
+    // Generic error page
+    errorHeading: "Ein Fehler ist aufgetreten",
+    errorUnexpected: "Ein unerwarteter Fehler ist aufgetreten.",
+    errorRetry: "Erneut versuchen",
+
+    // Category page
+    categoryFallbackTitle: "Kategorie",
+    subcategoriesLoadError: "Unterkategorien konnten nicht geladen werden.",
+
+    // Token login label
+    authTokenLabel: "Picnic Auth-Token",
+
+    // Search results count
+    resultFor: "für",
+
+    // Allergen badges
+    allergenTitle: "Allergene",
   },
 } as const;
 

--- a/src/lib/parse-recipe-detail.ts
+++ b/src/lib/parse-recipe-detail.ts
@@ -1,5 +1,10 @@
 import { cleanMarkdown, collectMarkdowns, stripColorTags } from "./pml-helpers";
-import type { NutritionRow, RecipeDetail, RecipeIngredient } from "./types";
+import type { AllergenInfo, NutritionRow, RecipeDetail, RecipeIngredient } from "./types";
+
+const ALLERGEN_CONFIRMED_BG = "#fef3c7";
+const ALLERGEN_CONFIRMED_TEXT = "#92400e";
+const ALLERGEN_MAY_CONTAIN_BG = "#f3f4f6";
+const ALLERGEN_MAY_CONTAIN_TEXT = "#4b5563";
 
 type PmlRecord = Record<string, unknown>;
 
@@ -292,9 +297,7 @@ function parseNutritionFromMarkdowns(markdowns: string[]): NutritionRow[] {
  * confirmed ("Die ausgewählten Zutaten enthalten:") and may-contain
  * ("Kann enthalten sein" / "Kan bevatten").
  */
-function parseAllergensFromMarkdowns(
-  markdowns: string[]
-): { confirmed: string[]; mayContain: string[] } {
+function parseAllergensFromMarkdowns(markdowns: string[]): AllergenInfo {
   const confirmed: string[] = [];
   const mayContain: string[] = [];
   let inAllergens = false;
@@ -309,22 +312,9 @@ function parseAllergensFromMarkdowns(
       continue;
     }
 
-    // Stop when we reach the next major content section
     if (/^(zutaten|ingrediënten|so wird|bereiding|schritt|stap)\b/i.test(clean)) break;
-
-    // Sub-header marking start of the confirmed allergen list
-    if (/zutaten.*enthalten|ingrediënten.*bevatten/i.test(clean)) {
-      afterIngredientHeader = true;
-      continue;
-    }
-
-    // Separator marking start of the may-contain list
-    if (/kann enthalten|kan bevatten/i.test(clean)) {
-      inMayContain = true;
-      continue;
-    }
-
-    // Skip generic notes (e.g. "Dieses Rezept enthält keine Allergene")
+    if (/zutaten.*enthalten|ingrediënten.*bevatten/i.test(clean)) { afterIngredientHeader = true; continue; }
+    if (/kann enthalten|kan bevatten/i.test(clean)) { inMayContain = true; continue; }
     if (/keine allergene|geen allergenen|enthält keine|bevat geen/i.test(clean)) continue;
     if (!clean || clean.length > 40) continue;
 
@@ -332,7 +322,18 @@ function parseAllergensFromMarkdowns(
     else if (afterIngredientHeader) confirmed.push(clean);
   }
 
-  return { confirmed, mayContain };
+  return {
+    confirmed: confirmed.map((text) => ({
+      text,
+      backgroundColor: ALLERGEN_CONFIRMED_BG,
+      textColor: ALLERGEN_CONFIRMED_TEXT,
+    })),
+    mayContain: mayContain.map((text) => ({
+      text,
+      backgroundColor: ALLERGEN_MAY_CONTAIN_BG,
+      textColor: ALLERGEN_MAY_CONTAIN_TEXT,
+    })),
+  };
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -475,7 +475,7 @@ export type RecipeDetail = {
   /** Per-serving nutrition extracted from the recipe page; empty when unavailable */
   recipeNutritionRows: NutritionRow[];
   /** Allergen names aggregated across all ingredients, extracted from the recipe page */
-  allergens: { confirmed: string[]; mayContain: string[] };
+  allergens: AllergenInfo;
 };
 
 export type RecipeDetailApiResponse = RecipeDetail;


### PR DESCRIPTION
## Summary

**Stacked PR series — please merge in order 1 → 5.** GitHub will auto-update the diff of each PR as the previous one merges into `main`.

| # | PR | Diff shown now |
|---|-------|------|
| 1 | Prettier setup | only prettier config |
| 2 | i18n | PR 1 + i18n commits |
| 3 | API error messages | PR 1–2 + 1 commit |
| 4 | Cookbook & recipes | PR 1–3 + 13 commits |
| 5 | **Reusable components + product detail i18n** (this PR) | PR 1–4 + 2 commits |

---

### What this PR adds (on top of PR 4 — cookbook)

**Component refactors (`1a2dc01`)**
- `src/components/recipe-hero-image.tsx`: extracted hero image with fallback placeholder
- `src/components/recipe-ingredient-row.tsx`: extracted ingredient row used in recipe detail
- `src/components/allergen-badges.tsx`: accepts optional `title`, `confirmedLabel`, `mayContainLabel` props with i18n fallbacks
- `src/lib/format-price.ts`: shared price formatting helper
- Recipe detail page (`src/app/recipe/[id]/page.tsx`) and parser (`src/lib/parse-recipe-detail.ts`) cleaned up

**Product detail i18n (`1cce269`)**
- Allergen badges, product price section, results view, error page, and category page use `useTranslations()` instead of hardcoded NL strings
- Additional translation keys added to `src/lib/i18n.ts`: `allergenTitle`, `addToCartButton`, `inCartLabel`, `bundleFromLabel`, `similarProductsTitle`, error page strings, category page strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)