### PR TITLE
feat: add NL recipe categories and upgrade picnic-api to 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "16.2.1",
-        "picnic-api": "^4.3.0",
+        "picnic-api": "^4.5.0",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
@@ -71,6 +71,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1656,6 +1657,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1715,6 +1717,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2240,6 +2243,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2583,6 +2587,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3151,6 +3156,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3336,6 +3342,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4562,6 +4569,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5476,9 +5484,9 @@
       "license": "MIT"
     },
     "node_modules/picnic-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.3.0.tgz",
-      "integrity": "sha512-0wFmXFJDq+nbRys2Qehls1B9Mz6vBEdCr7g4EBfA9DFnWi9iF8X3H6v7GCxpUAFktrCPFLMv0gIcTguaJENPMg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/picnic-api/-/picnic-api-4.5.0.tgz",
+      "integrity": "sha512-Yyi9n9Ek5xb8+qNEmvo0QjnEn0/wqimO8x0tOX8hS5iu9GAO0kWtKWO7JX0ouCtevzzFwpaEu6nFESeUyMrC3A==",
       "license": "MIT",
       "dependencies": {
         "jsonpath-plus": "^10.3.0"
@@ -5558,6 +5566,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5695,6 +5704,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5704,6 +5714,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6392,6 +6403,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6554,6 +6566,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6829,6 +6842,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "next": "16.2.1",
-    "picnic-api": "^4.3.0",
+    "picnic-api": "^4.5.0",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/src/app/api/cookbook/route.ts
+++ b/src/app/api/cookbook/route.ts
@@ -7,7 +7,9 @@ import { buildPicnicClient } from "@/lib/picnic-client";
 import { getRecipeCategories } from "@/lib/recipe-categories";
 import type { ApiErrorResponse, CookbookApiResponse } from "@/lib/types";
 
-const CATEGORY_ID_RE = /^recipe-cattree-[\w-]+$/;
+// DE uses short slug IDs (recipe-cattree-*); NL uses UUID-based content pages.
+const CATEGORY_ID_RE =
+  /^recipe-cattree-[\w-]+$|^meals-category-page-content\?category_id=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const SAVED_PAGE_ID = "saved-deep-dive-page-content";
 
 type SendRequestClient = {

--- a/src/lib/recipe-categories.ts
+++ b/src/lib/recipe-categories.ts
@@ -49,8 +49,171 @@ const DE_CATEGORIES: RecipeCategory[] = [
   { id: "recipe-cattree-l2-kids", name: "Für Kinder" },
 ];
 
+// NL uses UUID-based category pages. The id is the full Picnic API page path
+// passed to client.app.getPage(). Note: "meals-category-page" is a shell that
+// defers content via a SUSPENSE block; the actual recipes live in
+// "meals-category-page-content?category_id=<uuid>", which is what we call directly.
+const NL_CATEGORIES: RecipeCategory[] = [
+  {
+    id: "meals-category-page-content?category_id=c24af7dc-f056-4067-8953-6a8f85410bf8",
+    name: "Onder de 20 minuten",
+  },
+  {
+    id: "meals-category-page-content?category_id=8efb8aab-c728-4df0-a427-ef3e18727dd1",
+    name: "Weinig snijwerk",
+  },
+  {
+    id: "meals-category-page-content?category_id=0524acc5-8f37-4f2e-b85a-d58b6f24b528",
+    name: "Eenpansgerechten",
+  },
+  {
+    id: "meals-category-page-content?category_id=ba089fa4-23c1-4361-b5a1-b24be2e013b6",
+    name: "Pasta",
+  },
+  {
+    id: "meals-category-page-content?category_id=d420d519-0c36-4109-86a8-e46cb5723f6e",
+    name: "Ravioli & tortellini",
+  },
+  {
+    id: "meals-category-page-content?category_id=9f238cf6-355d-4c96-bd66-36a1bed2ca4e",
+    name: "Lasagne",
+  },
+  {
+    id: "meals-category-page-content?category_id=14a589b9-57d8-4c36-bbea-2e095879cafa",
+    name: "Noedels",
+  },
+  {
+    id: "meals-category-page-content?category_id=8c6641c8-3b40-4d02-ae1c-cffc74533403",
+    name: "Rijst",
+  },
+  {
+    id: "meals-category-page-content?category_id=3bc87ef2-97ae-4ced-a67d-ba1db99e835c",
+    name: "Risotto",
+  },
+  {
+    id: "meals-category-page-content?category_id=aaf728c0-faf4-4d2b-81be-381cf0bbf81f",
+    name: "Couscous, bulgur & quinoa",
+  },
+  {
+    id: "meals-category-page-content?category_id=32e341cb-b9dd-4fd7-bbb4-a374a279f973",
+    name: "Stamppot",
+  },
+  {
+    id: "meals-category-page-content?category_id=745a4764-9670-4973-aa56-435ab4eca1ec",
+    name: "Aardappelen",
+  },
+  {
+    id: "meals-category-page-content?category_id=b29cbecb-6ddf-4ee0-a35e-d069ffd3c157",
+    name: "Wraps & taco's",
+  },
+  {
+    id: "meals-category-page-content?category_id=88f94486-b6d3-46f5-860e-0a1e1067f31d",
+    name: "Pita & platbrood",
+  },
+  {
+    id: "meals-category-page-content?category_id=16ee3d05-7e6a-40bc-b00a-1825514e51cf",
+    name: "Pizza",
+  },
+  {
+    id: "meals-category-page-content?category_id=5989ff24-36c9-43b3-83b1-57676ea2ca6c",
+    name: "Burgers",
+  },
+  {
+    id: "meals-category-page-content?category_id=2701028e-a90c-4198-ad91-a2f66e201b1b",
+    name: "Ovenschotels",
+  },
+  {
+    id: "meals-category-page-content?category_id=a5401880-0ad7-458b-aa5f-eac84da20865",
+    name: "Traybakes",
+  },
+  {
+    id: "meals-category-page-content?category_id=77eca1e7-1f83-43ad-a184-25da3532f065",
+    name: "Plaattaart & flammkuchen",
+  },
+  {
+    id: "meals-category-page-content?category_id=95512d80-583a-4d7b-907c-6899dd08d941",
+    name: "Quiche",
+  },
+  {
+    id: "meals-category-page-content?category_id=fcf06318-8f10-494b-8655-d283b3fbad18",
+    name: "Airfryer",
+  },
+  {
+    id: "meals-category-page-content?category_id=392d64fb-9452-4b24-9d82-36eda598382a",
+    name: "Soep",
+  },
+  {
+    id: "meals-category-page-content?category_id=5c45153e-c5aa-4402-b186-0ae09ee69fc5",
+    name: "Vega",
+  },
+  {
+    id: "meals-category-page-content?category_id=c6c05c56-49e6-4121-8803-ec3845384d36",
+    name: "Vegan",
+  },
+  {
+    id: "meals-category-page-content?category_id=60ac9475-3d4c-49c0-bf72-65cfecdfcfec",
+    name: "Veel groente",
+  },
+  {
+    id: "meals-category-page-content?category_id=5ef7b94b-15ba-4428-964b-181ee15feb0c",
+    name: "Koolhydraatarm",
+  },
+  {
+    id: "meals-category-page-content?category_id=c771f79e-65c7-4c25-873f-f45d738b2d4f",
+    name: "Caloriearm",
+  },
+  {
+    id: "meals-category-page-content?category_id=e0842ef6-770b-4324-ba51-eb8ca5368c38",
+    name: "Zwangerproof",
+  },
+  {
+    id: "meals-category-page-content?category_id=a8ce9cb8-61ba-44ab-bb7a-429e835659af",
+    name: "Ontbijt",
+  },
+  {
+    id: "meals-category-page-content?category_id=16c7d514-9f19-4568-b673-4513db894215",
+    name: "Brunch & lunch",
+  },
+  {
+    id: "meals-category-page-content?category_id=c92f50ef-2704-4585-9a50-40778a25ddef",
+    name: "Drankjes",
+  },
+  {
+    id: "meals-category-page-content?category_id=13bd904b-b39b-470b-aa71-3c91a9f3d1cc",
+    name: "BBQ",
+  },
+  {
+    id: "meals-category-page-content?category_id=bea9f93c-35e4-46f1-8ab4-19943074268a",
+    name: "Budget",
+  },
+  {
+    id: "meals-category-page-content?category_id=98733940-cdfe-4009-951a-89878911763e",
+    name: "Koken met het seizoen",
+  },
+  {
+    id: "meals-category-page-content?category_id=fc6a8ef1-8410-4f20-8137-332ddc8bb749",
+    name: "Basisrecepten",
+  },
+  {
+    id: "meals-category-page-content?category_id=33fa5851-be5d-40ba-92a4-35a382cbe9b8",
+    name: "Verspakketten",
+  },
+  {
+    id: "meals-category-page-content?category_id=3aa8ebe4-d0b5-4cad-b638-dcbd1d3ab8c4",
+    name: "Jamie Oliver",
+  },
+  {
+    id: "meals-category-page-content?category_id=f54dd9a3-9009-4832-b326-ecda25cd8834",
+    name: "Eef Kookt Zo",
+  },
+  {
+    id: "meals-category-page-content?category_id=f4b5b9e4-bb06-4078-a44f-2814b0c12030",
+    name: "24Kitchen",
+  },
+];
+
 export function getRecipeCategories(countryCode: CountryCode): RecipeCategory[] {
   if (countryCode === "DE") return DE_CATEGORIES;
-  // NL category IDs differ; return empty until NL categories are mapped.
+  if (countryCode === "NL") return NL_CATEGORIES;
   return [];
 }


### PR DESCRIPTION
## Changes

- Add NL UUID-based recipe categories to `recipe-categories.ts`
- Update cookbook route regex to accept NL category page IDs (`meals-category-page-content?category_id=<uuid>`)
- Upgrade `picnic-api` from `^4.3.0` to `^4.5.0`