### PR TITLE
Several fixes and features

### DIFF
--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -16,11 +16,16 @@ type BadgeProps = {
 };
 
 export function Badge({ badge }: BadgeProps) {
-  const classes = VARIANT_CLASSES[badge.variant];
+  const hasApiColor = badge.backgroundColor || badge.textColor;
+  const classes = hasApiColor ? "" : VARIANT_CLASSES[badge.variant];
+  const style = hasApiColor
+    ? { backgroundColor: badge.backgroundColor, color: badge.textColor }
+    : undefined;
 
   return (
     <span
       className={`inline-block rounded-sm px-1.5 py-0.5 text-xs leading-tight font-medium ${classes}`}
+      style={style}
     >
       {badge.text}
     </span>

--- a/src/components/shared-header.tsx
+++ b/src/components/shared-header.tsx
@@ -7,10 +7,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import { SearchBar } from "@/components/search-bar";
 import { useCartOptional } from "@/contexts/cart-context";
-import { useCountryCode, useSwitchCountry, useTranslations } from "@/contexts/country-context";
+import { useTranslations } from "@/contexts/country-context";
 import { formatPrice } from "@/lib/format-price";
 import type { ApiErrorResponse, CartData } from "@/lib/types";
-import { SUPPORTED_COUNTRY_CODES } from "@/lib/types";
 
 // ─── Cart badge state ─────────────────────────────────────────────────────────
 
@@ -143,8 +142,6 @@ export function SharedHeader({ bottomBar, cartBadgeOverride = null }: SharedHead
     [router]
   );
 
-  const countryCode = useCountryCode();
-  const switchCountry = useSwitchCountry();
   const t = useTranslations();
 
   const handleSignOut = useCallback(async () => {
@@ -172,25 +169,6 @@ export function SharedHeader({ bottomBar, cartBadgeOverride = null }: SharedHead
             isLoading={false}
             initialQuery={urlQuery}
           />
-          {/* Country switcher */}
-          <div className="flex shrink-0 items-center gap-1">
-            {SUPPORTED_COUNTRY_CODES.map((code) => (
-              <button
-                key={code}
-                type="button"
-                onClick={() => switchCountry(code)}
-                className={`rounded px-2 py-1 text-xs font-semibold transition-colors ${
-                  code === countryCode
-                    ? "bg-picnic-red text-white"
-                    : "hover:text-foreground text-gray-500"
-                }`}
-                aria-pressed={code === countryCode}
-              >
-                {code}
-              </button>
-            ))}
-          </div>
-
           <button
             type="button"
             onClick={handleSignOut}

--- a/src/lib/parse-cart.ts
+++ b/src/lib/parse-cart.ts
@@ -123,7 +123,14 @@ function mapDecoratorsToBadges(decorators: RawDecorator[]): Badge[] {
         const text = asString(dec["text"]);
         if (!text) break;
         const isBundleLabel = text.toLowerCase().includes("bundel");
-        badges.push({ text, variant: isBundleLabel ? "bundle" : "promo" });
+        const backgroundColor = asString(dec["background_color"]) || undefined;
+        const textColor = asString(dec["text_color"]) || undefined;
+        badges.push({
+          text,
+          variant: isBundleLabel ? "bundle" : "promo",
+          backgroundColor,
+          textColor,
+        });
         break;
       }
       case "FRESH_LABEL": {

--- a/src/lib/parse-fusion-search.ts
+++ b/src/lib/parse-fusion-search.ts
@@ -190,6 +190,15 @@ export function parseFusionSearchSections(rawPage: unknown): {
   // Build flat product list from all sections
   const products = sections.flatMap((s) => s.products);
 
+  // Narrow searches return the result node WITHOUT client-side-filtering
+  // section structure — tiles sit directly under it. The header/wrapper/
+  // visual-sections logic finds nothing, so fall back to flat extraction
+  // scoped to the result node (reuses the existing tile-container walker).
+  if (products.length === 0) {
+    const flat = extractProductsFromWrappers([resultNode as PmlRecord], new Set());
+    return { sections: [], products: flat };
+  }
+
   return { sections, products };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,6 +53,10 @@ export type BadgeVariant =
 export type Badge = {
   text: string;
   variant: BadgeVariant;
+  /** Hex background color from the API decorator, when provided. */
+  backgroundColor?: string;
+  /** Hex text color from the API decorator, when provided. */
+  textColor?: string;
 };
 
 // ─── Highlight (colored subtext) ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

A batch of fixes and features on this branch:

- **Remove language toggle from header** (`3dc7ab7`) — drops the header language switcher.
- **Show results for narrow searches** (`88841ea`) — searches like "mortadella"/"redefine" returned "No results" on the web while the app showed products. The Fusion search parser only extracted products from `client-side-filtering-section-*` structures, which narrow searches omit. Now falls back to flat tile extraction scoped to the result node when the structured pass yields nothing.
- **Apply API label colors on cart badges** (`e798b9e`) — cart `LABEL`/`PROMO` decorators carry `background_color`/`text_color` (e.g. the green "family" label) but those were discarded and the badge was hardcoded yellow. The colors are now threaded through the `Badge` type and applied inline, falling back to the variant color when absent.

## Verification

No automated test framework in this repo — validate manually against a logged-in dev server:

- Search "mortadella" / "redefine" → products now appear; broad searches (e.g. "tomaten") still show grouped sections; nonsense terms still show the empty state.
- Open the cart with the family item → the label renders in its API color (green) instead of yellow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)