### PR TITLE
Fixed subcategories title and translations

### DIFF
--- a/src/components/product-description.tsx
+++ b/src/components/product-description.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from "@/contexts/country-context";
 import { renderMarkdownBold } from "@/lib/render-markdown-bold";
 
 type ProductDescriptionProps = {
@@ -5,11 +6,12 @@ type ProductDescriptionProps = {
 };
 
 export function ProductDescription({ description }: ProductDescriptionProps) {
+  const t = useTranslations()
   if (!description) return null;
 
   return (
     <div>
-      <h2 className="text-foreground mb-2 text-lg font-semibold">Beschrijving</h2>
+      <h2 className="text-foreground mb-2 text-lg font-semibold">{t.descriptionTitle}</h2>
       <p className="text-sm leading-relaxed whitespace-pre-line text-gray-600">
         {renderMarkdownBold(description)}
       </p>

--- a/src/components/subcategory-view.tsx
+++ b/src/components/subcategory-view.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { BackArrowIcon } from "@/components/back-arrow-icon";
 import { ErrorView } from "@/components/error-view";
 import { LoadingSpinner } from "@/components/loading-spinner";
-import { useCountryCode } from "@/contexts/country-context";
+import { useCountryCode, useTranslations } from "@/contexts/country-context";
 import type { CategoryItem } from "@/lib/category-types";
 import { buildImageUrl } from "@/lib/image-url";
 
@@ -30,6 +30,7 @@ export function SubcategoryView({
   onRetry,
   onSubcategoryTap,
 }: SubcategoryViewProps) {
+  const t = useTranslations();
   return (
     <div>
       <button
@@ -38,7 +39,7 @@ export function SubcategoryView({
         className="mb-4 flex items-center gap-1 text-sm font-medium text-red-600 hover:text-red-700"
       >
         <BackArrowIcon />
-        Terug
+        {t.backButton}
       </button>
 
       <h2 className="text-foreground mb-3 text-lg font-semibold">{categoryName}</h2>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -106,6 +106,7 @@ const translations = {
     inCartLabel: "in mandje",
     bundleFromLabel: "Vanaf",
     similarProductsTitle: "Vergelijkbare producten",
+    descriptionTitle: "Beschrijving",
 
     // Category grid
     allCategoriesTitle: "Alle categorieën",
@@ -281,12 +282,13 @@ const translations = {
     inCartLabel: "im Warenkorb",
     bundleFromLabel: "Ab",
     similarProductsTitle: "Ähnliche Produkte",
+    descriptionTitle: "Beschreibung",
 
     // Category grid
     allCategoriesTitle: "Alle Kategorien",
 
     // Shortcut list
-    shortcutSectionTitle: "Schnell zu",
+    shortcutSectionTitle: "Schnellzugriff",
 
     // Section nav bar
     sectionNavGoTo: "Gehe zu",

--- a/src/lib/parse-subcategories.ts
+++ b/src/lib/parse-subcategories.ts
@@ -42,9 +42,23 @@ export function parseSubcategoryPage(rawPage: unknown): CategoryItem[] {
  * Returns null if the header or title is missing.
  */
 export function extractPageTitle(rawPage: unknown): string | null {
-  if (typeof rawPage !== "object" || rawPage === null) return null;
-  const header = (rawPage as Record<string, unknown>).header;
-  if (typeof header !== "object" || header === null) return null;
+  if (typeof rawPage !== "object" || rawPage === null) {
+    return null;
+  }
+
+  const page = rawPage as Record<string, unknown>;
+
+  const header =
+    typeof page.layout === "object" &&
+    page.layout !== null &&
+    "header" in page.layout
+      ? (page.layout as Record<string, unknown>).header
+      : page.header;
+
+  if (typeof header !== "object" || header === null) {
+    return null;
+  }
+
   const title = (header as Record<string, unknown>).title;
   return typeof title === "string" ? title : null;
 }


### PR DESCRIPTION
I saw that subcategories haven't correctly displayed the parent categorie as title and figured out the the rawPage output differs, why it goes to fallback title. Now it should always display the correct title.

I also added missing and corrected some translations