### PR TITLE
feat: interactive authKey script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Your Picnic Login credentials
+PICNIC_EMAIL="your@mail.com"
+PICNIC_PASSWORD="superSecretPassword1"
+
+# Available codes: NL, DE
+COUNTRY_CODE="DE"

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "prettier": "^3.8.3",
@@ -2904,6 +2905,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "prettier": "^3.8.3",

--- a/src/generateAuthKey.js
+++ b/src/generateAuthKey.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import "dotenv/config";
+import { stdin as input, stdout as output } from "node:process";
+import { createInterface } from "node:readline/promises";
+import PicnicClient from "picnic-api";
+
+const { PICNIC_EMAIL: EMAIL, PICNIC_PASSWORD: PASSWORD, COUNTRY_CODE: COUNTRYCODE } = process.env;
+
+if (!EMAIL || !PASSWORD || !COUNTRYCODE) {
+  console.error("Please set PICNIC_EMAIL, PICNIC_PASSWORD and COUNTRY_CODE in your .env file.");
+  process.exit(1);
+}
+
+const client = new PicnicClient({
+  countryCode: COUNTRYCODE,
+});
+
+async function verify2FA() {
+  const rl = createInterface({ input, output });
+
+  try {
+    console.log("Requesting SMS code...");
+    await client.auth.generate2FACode("SMS");
+
+    const code = (await rl.question("Enter the SMS code: ")).trim();
+
+    if (!code) {
+      throw new Error("No code entered.");
+    }
+
+    console.log("Verifying...");
+
+    const { authKey } = await client.auth.verify2FACode(code);
+    return authKey;
+  } finally {
+    rl.close();
+  }
+}
+
+async function main() {
+  console.log("Logging in...");
+
+  const auth = await client.auth.login(EMAIL, PASSWORD);
+
+  const authKey = auth.second_factor_authentication_required ? await verify2FA() : auth.authKey;
+
+  console.log("\n✅ Auth Key:");
+  console.log(authKey);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
I added a simple cli script which uses dotenv config for a better login flow, as when 2fa is enabled it waits for user input.

If you want to add this, we maybe need to add a small section into the readme, so ppl know.