### PR TITLE
chore: make auth-key script runnable and repo-consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ Please report issues in the [Github issues section](https://github.com/MRVDH/pic
 #### How do I run a local instance?
 
 Clone or download the repo, run `npm install`, `npm run build` and then `npm run start`.
+
+#### How do I generate an auth key?
+
+If you'd rather not log in through the web interface, there's a small CLI for it. Copy `.env.example` to `.env`, fill in your Picnic email, password and country code (`NL` or `DE`), then run `npm run auth-key`. If your account has 2FA enabled it asks for the SMS code and prints the auth key when done.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "auth-key": "node src/generate-auth-key.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/src/generate-auth-key.mjs
+++ b/src/generate-auth-key.mjs
@@ -1,20 +1,28 @@
 #!/usr/bin/env node
 
+// Interactive CLI to obtain a Picnic auth key for local development.
+// Reads credentials from .env (see .env.example) and walks the 2FA SMS
+// flow when the account requires it. Run with: npm run auth-key
 import "dotenv/config";
 import { stdin as input, stdout as output } from "node:process";
 import { createInterface } from "node:readline/promises";
 import PicnicClient from "picnic-api";
 
-const { PICNIC_EMAIL: EMAIL, PICNIC_PASSWORD: PASSWORD, COUNTRY_CODE: COUNTRYCODE } = process.env;
+const SUPPORTED_COUNTRY_CODES = ["NL", "DE"];
 
-if (!EMAIL || !PASSWORD || !COUNTRYCODE) {
+const { PICNIC_EMAIL, PICNIC_PASSWORD, COUNTRY_CODE } = process.env;
+
+if (!PICNIC_EMAIL || !PICNIC_PASSWORD || !COUNTRY_CODE) {
   console.error("Please set PICNIC_EMAIL, PICNIC_PASSWORD and COUNTRY_CODE in your .env file.");
   process.exit(1);
 }
 
-const client = new PicnicClient({
-  countryCode: COUNTRYCODE,
-});
+if (!SUPPORTED_COUNTRY_CODES.includes(COUNTRY_CODE)) {
+  console.error(`COUNTRY_CODE must be one of: ${SUPPORTED_COUNTRY_CODES.join(", ")}.`);
+  process.exit(1);
+}
+
+const client = new PicnicClient({ countryCode: COUNTRY_CODE });
 
 async function verify2FA() {
   const rl = createInterface({ input, output });
@@ -24,13 +32,11 @@ async function verify2FA() {
     await client.auth.generate2FACode("SMS");
 
     const code = (await rl.question("Enter the SMS code: ")).trim();
-
     if (!code) {
       throw new Error("No code entered.");
     }
 
     console.log("Verifying...");
-
     const { authKey } = await client.auth.verify2FACode(code);
     return authKey;
   } finally {
@@ -40,12 +46,15 @@ async function verify2FA() {
 
 async function main() {
   console.log("Logging in...");
+  const login = await client.auth.login(PICNIC_EMAIL, PICNIC_PASSWORD);
 
-  const auth = await client.auth.login(EMAIL, PASSWORD);
+  const authKey = login.second_factor_authentication_required ? await verify2FA() : login.authKey;
 
-  const authKey = auth.second_factor_authentication_required ? await verify2FA() : auth.authKey;
+  if (!authKey) {
+    throw new Error("Login failed: no auth key returned. Check your credentials.");
+  }
 
-  console.log("\n✅ Auth Key:");
+  console.log("\n✅ Auth key:");
   console.log(authKey);
 }
 


### PR DESCRIPTION
Follow-up to #31.

- Rename `src/generateAuthKey.js` to `src/generate-auth-key.mjs`: kebab-case to match the rest of the repo, and `.mjs` so Node runs it as ESM without the `MODULE_TYPELESS_PACKAGE_JSON` warning (it would also fail outright on Node < 20.19).
- Add an `npm run auth-key` script so it doesn't need a raw `node` invocation.
- Document it in the README under a new FAQ entry.
- Validate `COUNTRY_CODE` against the supported codes and guard against a missing auth key, so failures give a clear message instead of printing `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)