### PR TITLE
fix: comma decimals and skip fake discount highlighting

### DIFF
--- a/src/components/product/product-card.tsx
+++ b/src/components/product/product-card.tsx
@@ -5,14 +5,13 @@ import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 
+import { Badge } from "@/components/ui/badge";
+import { PriceDisplay } from "@/components/ui/price-display";
+import { QuantityStepper } from "@/components/ui/quantity-stepper";
 import { useCart } from "@/contexts/cart-context";
 import { useCountryCode, useTranslations } from "@/contexts/country-context";
 import { buildImageUrl } from "@/lib/core/image-url";
 import type { BundleProgress, Product } from "@/lib/core/types";
-
-import { Badge } from "@/components/ui/badge";
-import { PriceDisplay } from "@/components/ui/price-display";
-import { QuantityStepper } from "@/components/ui/quantity-stepper";
 
 const PLACEHOLDER_IMAGE = "/placeholder-product.svg";
 const FLAG_SIZE = 14;
@@ -44,7 +43,10 @@ export function ProductCard({ product, href }: ProductCardProps) {
   // When a bundle threshold is active, compute the discounted unit price.
   const bundleUnitPrice = getActiveBundlePrice(bundleProgress, quantity);
   const effectiveDisplayPrice = bundleUnitPrice ?? product.displayPrice;
-  const bundleOriginalPrice = bundleUnitPrice ? product.displayPrice : null;
+  const bundleOriginalPrice =
+    bundleUnitPrice !== null && bundleUnitPrice < product.displayPrice
+      ? product.displayPrice
+      : null;
 
   const cardContent = (
     <div
@@ -256,4 +258,3 @@ function CartActionOverlay({
     </div>
   );
 }
-

--- a/src/components/ui/price-display.tsx
+++ b/src/components/ui/price-display.tsx
@@ -13,8 +13,12 @@ type PriceDisplayProps = {
   displayPriceColor?: string | null;
 };
 
-export function PriceDisplay({ displayPrice, originalPrice, displayPriceColor }: PriceDisplayProps) {
-  const hasDiscount = originalPrice !== null;
+export function PriceDisplay({
+  displayPrice,
+  originalPrice,
+  displayPriceColor,
+}: PriceDisplayProps) {
+  const hasDiscount = originalPrice !== null && originalPrice > displayPrice;
   const priceColorClass = displayPriceColor
     ? ""
     : hasDiscount

--- a/src/lib/core/format-price.ts
+++ b/src/lib/core/format-price.ts
@@ -2,10 +2,10 @@ import { CENTS_DIVISOR } from "@/lib/core/types";
 
 /**
  * Format a price in cents to a display string without currency symbol.
- * NL/DE/FR all use a comma as decimal separator (e.g. 149 → "1,49").
+ * Uses dot as decimal separator (e.g. 149 → "1.49").
  */
 export function formatPrice(cents: number): string {
-  return (cents / CENTS_DIVISOR).toFixed(2).replace(".", ",");
+  return (cents / CENTS_DIVISOR).toFixed(2);
 }
 
 /**

--- a/src/lib/core/format-price.ts
+++ b/src/lib/core/format-price.ts
@@ -2,10 +2,10 @@ import { CENTS_DIVISOR } from "@/lib/core/types";
 
 /**
  * Format a price in cents to a display string without currency symbol.
- * Uses dot as decimal separator (e.g. 149 → "1.49").
+ * NL/DE/FR all use a comma as decimal separator (e.g. 149 → "1,49").
  */
 export function formatPrice(cents: number): string {
-  return (cents / CENTS_DIVISOR).toFixed(2);
+  return (cents / CENTS_DIVISOR).toFixed(2).replace(".", ",");
 }
 
 /**

--- a/src/lib/product/extract-card-data.ts
+++ b/src/lib/product/extract-card-data.ts
@@ -1,4 +1,11 @@
 // Per-tile data extraction for converting PML selling-unit tiles into Product metadata.
+import type {
+  Badge,
+  BadgeVariant,
+  Highlight,
+  PromoPlacement,
+  SubtitleIcon,
+} from "@/lib/core/types";
 import type { AnalyticsContext, PmlNode } from "@/lib/pml/pml-helpers";
 import {
   cleanMarkdown,
@@ -8,7 +15,6 @@ import {
   stripColorTags,
 } from "@/lib/pml/pml-helpers";
 import { collectLabels } from "@/lib/pml/pml-product-helpers";
-import type { Badge, BadgeVariant, Highlight, PromoPlacement, SubtitleIcon } from "@/lib/core/types";
 
 /** Extract a promotion label from the analytics contexts (e.g. "3 voor €5"). */
 export function extractPromotionLabel(contexts: AnalyticsContext[] | undefined): string | null {
@@ -157,7 +163,9 @@ function splitFlankingIcons(row: PmlNode): {
 
   const firstTextIdx = tokens.findIndex((t) => t.kind === "text");
   if (firstTextIdx === -1) {
-    const firstIcon = tokens.find((t): t is { kind: "icon"; icon: SubtitleIcon } => t.kind === "icon");
+    const firstIcon = tokens.find(
+      (t): t is { kind: "icon"; icon: SubtitleIcon } => t.kind === "icon"
+    );
     return { leading: firstIcon?.icon ?? null, trailing: null };
   }
   const lastTextIdx = tokens.map((t) => t.kind).lastIndexOf("text");
@@ -306,7 +314,9 @@ export function extractTextStackInfo(
       const highlightColor = extractInnerColor(md);
       if (highlightColor) {
         result.highlight = { text: clean, color: highlightColor };
-      } else {
+      } else if (!/^\d+[.,]\d{2}$/.test(clean) && !clean.startsWith("€")) {
+        // Picnic often puts the price in the row after the name when there
+        // is no brand. Do not treat a bare price as a brand label.
         result.brand = clean;
       }
     }


### PR DESCRIPTION
## Summary
- Format prices with a comma (`1,49`) so NL/DE/FR match local number format.
- Treat `originalPrice` as a discount only when it is actually higher than the display price, and ignore dummy qty-1 `priceRanges` that repeat the same unit price.
- Stop parsing a bare tile price (e.g. `0.55`) as the product brand.

Picnic DE tiles often send a qty-1 price range equal to the regular price. With that item in the cart, the card showed a red price plus a strikethrough of the same amount (e.g. Ur Hefe `0,55` / `0,55`).

## Test plan
- [ ] Search DE catalog for `Hefe`
- [ ] Discounted item (Trockenbackhefe): red current price + grey strikethrough original (`1,09` / `1,29`)
- [ ] Regular item in cart (Oma's Ur Hefe, qty ≥ 1): single black `0,55`, no strikethrough
- [ ] No extra `0,55` under the product name
- [ ] Cart header / totals also use a comma


Made with [Cursor](https://cursor.com)