### PR TITLE
feat(recipe): edit selected ingredients like the app

### DIFF
--- a/src/app/(app)/recipe/[id]/page.tsx
+++ b/src/app/(app)/recipe/[id]/page.tsx
@@ -123,6 +123,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
       .filter((ing) => checkedIds.has(ing.id))
       .map((ing) => ({
         id: ing.id,
+        ingredientId: ing.ingredientId,
         count: Math.max(1, Math.ceil((ing.quantity * portions) / recipe.portions)),
       }));
     try {

--- a/src/app/(app)/recipe/[id]/page.tsx
+++ b/src/app/(app)/recipe/[id]/page.tsx
@@ -8,6 +8,7 @@ import { CartToast } from "@/components/cart/cart-toast";
 import { AllergenBadges } from "@/components/product/allergen-badges";
 import { NutritionTable } from "@/components/product/nutrition-table";
 import { FavoriteButton } from "@/components/recipe/favorite-button";
+import { IngredientEditModal } from "@/components/recipe/ingredient-edit-modal";
 import { RecipeHeroImage } from "@/components/recipe/recipe-hero-image";
 import { RecipeIngredientRow } from "@/components/recipe/recipe-ingredient-row";
 import { ErrorView } from "@/components/ui/error-view";
@@ -40,6 +41,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
   const [addState, setAddState] = useState<AddState>("idle");
   const [confirmedPortions, setConfirmedPortions] = useState<number | null>(null);
   const [checkedIds, setCheckedIds] = useState<Set<string>>(() => new Set());
+  const [editingIngredientId, setEditingIngredientId] = useState<string | null>(null);
 
   usePageTitle(pageState.status === "success" ? pageState.recipe.name : t.cookbookTitle);
 
@@ -70,6 +72,28 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
     return () => controller.abort();
   }, [recipeId, t.recipeLoadError]);
 
+  /** Merge a freshly fetched recipe into page state; shared by the portions
+   *  debounce below and by the ingredient editor's save handler. */
+  const applyFetchedRecipe = useCallback((fetched: RecipeDetail, forPortions: number) => {
+    setConfirmedPortions(forPortions);
+    setPageState((prev) =>
+      prev.status === "success"
+        ? {
+            status: "success",
+            recipe: {
+              ...prev.recipe,
+              portions: fetched.portions,
+              ingredients: fetched.ingredients,
+              steps: fetched.steps,
+              stepsPortionWarning: fetched.stepsPortionWarning,
+              recipeNutritionRows: fetched.recipeNutritionRows,
+            },
+          }
+        : prev
+    );
+    setCheckedIds(new Set(fetched.ingredients.filter((i) => !i.isCondiment).map((i) => i.id)));
+  }, []);
+
   useEffect(() => {
     if (pageState.status !== "success") return;
     if (confirmedPortions === null || confirmedPortions === portions) return;
@@ -82,26 +106,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
         .then((res) => res.json())
         .then((data: RecipeDetail & Partial<ApiErrorResponse>) => {
           if (!("error" in data) || !data.error) {
-            const fetched = data as RecipeDetail;
-            setConfirmedPortions(portions);
-            setPageState((prev) =>
-              prev.status === "success"
-                ? {
-                    status: "success",
-                    recipe: {
-                      ...prev.recipe,
-                      portions: fetched.portions,
-                      ingredients: fetched.ingredients,
-                      steps: fetched.steps,
-                      stepsPortionWarning: fetched.stepsPortionWarning,
-                      recipeNutritionRows: fetched.recipeNutritionRows,
-                    },
-                  }
-                : prev
-            );
-            setCheckedIds(
-              new Set(fetched.ingredients.filter((i) => !i.isCondiment).map((i) => i.id))
-            );
+            applyFetchedRecipe(data as RecipeDetail, portions);
           }
         })
         .catch((err: unknown) => {
@@ -113,7 +118,7 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
       clearTimeout(timer);
       controller.abort();
     };
-  }, [portions, confirmedPortions, pageState.status, recipeId]);
+  }, [portions, confirmedPortions, pageState.status, recipeId, applyFetchedRecipe]);
 
   const handleAddToCart = useCallback(async () => {
     if (pageState.status !== "success" || addState !== "idle") return;
@@ -304,6 +309,11 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
                           return next;
                         })
                       }
+                      onEdit={
+                        ing.ingredientId
+                          ? () => setEditingIngredientId(ing.ingredientId)
+                          : undefined
+                      }
                     />
                   ))}
                 </div>
@@ -328,6 +338,11 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
                           else next.add(ing.id);
                           return next;
                         })
+                      }
+                      onEdit={
+                        ing.ingredientId
+                          ? () => setEditingIngredientId(ing.ingredientId)
+                          : undefined
                       }
                     />
                   ))}
@@ -380,6 +395,26 @@ function RecipeDetailInner({ recipeId }: { recipeId: string }) {
               mayContainLabel={t.recipeMayContain}
             />
           </section>
+        )}
+        {editingIngredientId && (
+          <IngredientEditModal
+            recipeId={recipeId}
+            ingredientId={editingIngredientId}
+            portions={pricePortions}
+            onClose={() => setEditingIngredientId(null)}
+            onSaved={() => {
+              setEditingIngredientId(null);
+              fetch(`/api/recipe/${encodeURIComponent(recipeId)}?portions=${pricePortions}`)
+                .then((res) => res.json())
+                .then((data: RecipeDetail & Partial<ApiErrorResponse>) => {
+                  if (!("error" in data) || !data.error) {
+                    applyFetchedRecipe(data as RecipeDetail, pricePortions);
+                  }
+                })
+                .catch(() => {});
+              refresh();
+            }}
+          />
         )}
       </main>
     </div>

--- a/src/app/api/recipe/[id]/add-to-cart/route.ts
+++ b/src/app/api/recipe/[id]/add-to-cart/route.ts
@@ -7,7 +7,7 @@ import type { PicnicClientInstance } from "@/lib/core/picnic-client";
 
 const RECIPE_ID_RE = /^[0-9a-f]{24}$/;
 
-type SelectedIngredient = { id: string; count: number };
+type SelectedIngredient = { id: string; count: number; ingredientId?: string | null };
 
 type RequestBody = {
   portions: number;
@@ -58,7 +58,15 @@ export async function POST(
             product_id: item.id,
             count: item.count,
             selling_unit_contexts: [
-              { type: "SELLING_GROUP", selling_group_id: id, selling_group_creator_type: "PIM" },
+              { type: "MEAL_PLAN", day_relative_to_slot: 999, number_of_servings: portions },
+              {
+                type: "SELLING_GROUP",
+                selling_group_id: id,
+                selling_group_creator_type: "PIM",
+                selling_group_component_id: item.ingredientId ?? null,
+                selling_group_component_type: "CORE",
+                selling_group_component_swap_type: null,
+              },
             ],
           },
           true

--- a/src/app/api/recipe/[id]/ingredient/[ingredientId]/route.ts
+++ b/src/app/api/recipe/[id]/ingredient/[ingredientId]/route.ts
@@ -1,0 +1,207 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { isApiAuthError } from "@/lib/core/api-error";
+import { readAuthToken, readCountryCode } from "@/lib/core/auth";
+import { buildPicnicClient } from "@/lib/core/picnic-client";
+import type { PicnicClientInstance } from "@/lib/core/picnic-client";
+import type { IngredientEditApiResponse, IngredientEditData } from "@/lib/core/types";
+import { parseIngredientEdit } from "@/lib/recipe/parse-ingredient-edit";
+
+const RECIPE_ID_RE = /^[0-9a-f]{24}$/;
+/** PIM ingredients are UUIDs; user-defined ones are 32 hex chars without dashes. */
+const INGREDIENT_ID_RE = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/;
+
+type SendRequestClient = PicnicClientInstance & {
+  sendRequest: (method: string, path: string, body: unknown, fusion: boolean) => Promise<unknown>;
+};
+
+type SaveBody = { portions: number; quantities: Record<string, number> };
+
+/** Picnic fails to render this page for portions < 1, which is the app bug we fix. */
+function clampPortions(value: number | null): number {
+  return value !== null && Number.isFinite(value) && value > 0 ? Math.floor(value) : 1;
+}
+
+async function fetchEditPage(
+  client: SendRequestClient,
+  recipeId: string,
+  ingredientId: string,
+  portions: number
+): Promise<unknown> {
+  return client.sendRequest(
+    "GET",
+    `/pages/selling-group-component-edit-page?ingredient_id=${encodeURIComponent(
+      ingredientId
+    )}&selling_group_id=${encodeURIComponent(recipeId)}&portions=${portions}`,
+    null,
+    true
+  );
+}
+
+function validate(
+  request: NextRequest,
+  id: string,
+  ingredientId: string
+): { error: NextResponse<{ error: string }> } | { token: string } {
+  const token = readAuthToken(request);
+  if (!token) {
+    return { error: NextResponse.json({ error: "Authentication required" }, { status: 401 }) };
+  }
+  if (!RECIPE_ID_RE.test(id) || !INGREDIENT_ID_RE.test(ingredientId)) {
+    return {
+      error: NextResponse.json({ error: "Invalid recipe or ingredient ID" }, { status: 400 }),
+    };
+  }
+  return { token };
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; ingredientId: string }> }
+): Promise<NextResponse<IngredientEditApiResponse | { error: string }>> {
+  const { id, ingredientId } = await params;
+  const checked = validate(request, id, ingredientId);
+  if ("error" in checked) return checked.error;
+
+  try {
+    const client = buildPicnicClient(checked.token, readCountryCode(request));
+    const portionsParam = request.nextUrl.searchParams.get("portions");
+    const portions = clampPortions(portionsParam ? parseInt(portionsParam, 10) : null);
+    const rawPage = await fetchEditPage(
+      client as unknown as SendRequestClient,
+      id,
+      ingredientId,
+      portions
+    );
+    return NextResponse.json(parseIngredientEdit(rawPage, ingredientId));
+  } catch (error) {
+    if (isApiAuthError(error)) {
+      return NextResponse.json({ error: "Your token has expired" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Failed to load ingredient alternatives" }, { status: 502 });
+  }
+}
+
+/**
+ * Decide which swap type the save task gets, mirroring the app's own rule:
+ * staying inside the ingredient's own variants is a WITHIN swap, picking one of
+ * the suggestions below it is a POPULAR_SELECTION, anything else came from search.
+ */
+function resolveSwapType(
+  parsed: IngredientEditData,
+  selectedIds: string[]
+): "WITHIN_SELLING_GROUP_COMPONENT" | "POPULAR_SELECTION" | "SEARCH_SELECTION" {
+  const ownIds = parsed.groups[0]?.alternatives.map((a) => a.id) ?? [];
+  const suggestedIds = parsed.groups.slice(1).flatMap((g) => g.alternatives.map((a) => a.id));
+  const originalIds = Object.keys(parsed.selected);
+
+  const areSameSellingUnits = selectedIds.every((selectedId) => originalIds.includes(selectedId));
+  const isWithinSameComponent =
+    areSameSellingUnits || selectedIds.some((selectedId) => ownIds.includes(selectedId));
+  if (isWithinSameComponent) return "WITHIN_SELLING_GROUP_COMPONENT";
+  return selectedIds.some((selectedId) => suggestedIds.includes(selectedId))
+    ? "POPULAR_SELECTION"
+    : "SEARCH_SELECTION";
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; ingredientId: string }> }
+): Promise<NextResponse<{ success: true } | { error: string }>> {
+  const { id, ingredientId } = await params;
+  const checked = validate(request, id, ingredientId);
+  if ("error" in checked) return checked.error;
+
+  let body: SaveBody;
+  try {
+    body = (await request.json()) as SaveBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  if (typeof body.quantities !== "object" || body.quantities === null) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const portions = clampPortions(body.portions);
+  const selected: Record<string, number> = {};
+  for (const [sellingUnitId, count] of Object.entries(body.quantities)) {
+    if (typeof count === "number" && count > 0) selected[sellingUnitId] = Math.floor(count);
+  }
+  const selectedIds = Object.keys(selected);
+
+  try {
+    const client = buildPicnicClient(
+      checked.token,
+      readCountryCode(request)
+    ) as unknown as SendRequestClient;
+
+    // Deselecting everything removes the ingredient from the recipe.
+    if (selectedIds.length === 0) {
+      await client.sendRequest(
+        "POST",
+        "/pages/task/delete-selling-group-component",
+        { payload: { selling_group_component_id: ingredientId, selling_group_id: id } },
+        true
+      );
+      return NextResponse.json({ success: true });
+    }
+
+    // Re-read the page server-side so the swap type is derived from Picnic's own
+    // grouping rather than from whatever the client claims.
+    const parsed = parseIngredientEdit(
+      await fetchEditPage(client, id, ingredientId, portions),
+      ingredientId
+    );
+    const swapType = resolveSwapType(parsed, selectedIds);
+
+    // Mirrors the app: when the selection stays within the units already saved and
+    // more than one was saved, every original is explicitly zeroed first.
+    const originalIds = Object.keys(parsed.selected);
+    const quantityById: Record<string, number> = {};
+    if (selectedIds.every((sid) => originalIds.includes(sid)) && originalIds.length > 1) {
+      for (const originalId of originalIds) quantityById[originalId] = 0;
+    }
+    for (const [sellingUnitId, count] of Object.entries(selected)) {
+      quantityById[sellingUnitId] = count;
+    }
+
+    const saveResult = (await client.sendRequest(
+      "POST",
+      "/pages/task/save-selling-group-edit-task",
+      {
+        payload: {
+          requested_sellable_portions: String(portions),
+          selling_group_component_id: ingredientId,
+          selling_group_id: id,
+          selling_unit_quantity_by_id: quantityById,
+          swapType,
+        },
+      },
+      true
+    )) as { shouldUpdateCart?: boolean } | null;
+
+    if (saveResult?.shouldUpdateCart) {
+      await client.sendRequest(
+        "POST",
+        "/pages/task/assign-sellable-component-to-day",
+        {
+          payload: {
+            component_swap_type: swapType,
+            portions: String(portions),
+            required_amount_by_selling_unit_id: selected,
+            selected_component_id: ingredientId,
+            selling_group_id: id,
+          },
+        },
+        true
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (isApiAuthError(error)) {
+      return NextResponse.json({ error: "Your token has expired" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Failed to save ingredient selection" }, { status: 502 });
+  }
+}

--- a/src/components/recipe/ingredient-edit-modal.tsx
+++ b/src/components/recipe/ingredient-edit-modal.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import Image from "next/image";
+
+import { useCountryCode, useTranslations } from "@/contexts/country-context";
+import { TOKEN_EXPIRED_REDIRECT } from "@/lib/core/constants";
+import { formatEuroPrice } from "@/lib/core/format-price";
+import { buildImageUrl } from "@/lib/core/image-url";
+import type {
+  ApiErrorResponse,
+  CountryCode,
+  IngredientAlternative,
+  IngredientEditData,
+} from "@/lib/core/types";
+
+const PLACEHOLDER = "/placeholder-product.svg";
+
+type IngredientEditModalProps = {
+  recipeId: string;
+  ingredientId: string;
+  portions: number;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ready"; data: IngredientEditData }
+  | { status: "error"; message: string };
+
+export function IngredientEditModal({
+  recipeId,
+  ingredientId,
+  portions,
+  onClose,
+  onSaved,
+}: IngredientEditModalProps) {
+  const t = useTranslations();
+  const countryCode = useCountryCode();
+  const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
+  const [quantities, setQuantities] = useState<Record<string, number>>({});
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(
+      `/api/recipe/${encodeURIComponent(recipeId)}/ingredient/${encodeURIComponent(
+        ingredientId
+      )}?portions=${portions}`,
+      { signal: controller.signal }
+    )
+      .then((res) => res.json())
+      .then((data: IngredientEditData & Partial<ApiErrorResponse>) => {
+        if ("error" in data && data.error) {
+          if (data.error === "Your token has expired") {
+            window.location.href = TOKEN_EXPIRED_REDIRECT;
+            return;
+          }
+          setLoadState({ status: "error", message: t.recipeEditLoadError });
+          return;
+        }
+        setLoadState({ status: "ready", data });
+        setQuantities({ ...data.selected });
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setLoadState({ status: "error", message: t.recipeEditLoadError });
+      });
+    return () => controller.abort();
+  }, [recipeId, ingredientId, portions, t.recipeEditLoadError]);
+
+  const select = useCallback((alternative: IngredientAlternative) => {
+    if (alternative.isUnavailable) return;
+    // Picking a different product replaces the selection, as the app does.
+    setQuantities((prev) => (prev[alternative.id] ? {} : { [alternative.id]: 1 }));
+  }, []);
+
+  const setCount = useCallback((id: string, delta: number) => {
+    setQuantities((prev) => {
+      const next = Math.max(0, (prev[id] ?? 0) + delta);
+      if (next === 0) return {};
+      return { [id]: next };
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch(
+        `/api/recipe/${encodeURIComponent(recipeId)}/ingredient/${encodeURIComponent(ingredientId)}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ portions, quantities }),
+        }
+      );
+      if (!res.ok) {
+        setSaveError(t.recipeEditSaveError);
+        setSaving(false);
+        return;
+      }
+      onSaved();
+    } catch {
+      setSaveError(t.recipeEditSaveError);
+      setSaving(false);
+    }
+  }, [saving, recipeId, ingredientId, portions, quantities, onSaved, t.recipeEditSaveError]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-card-bg flex max-h-[90vh] w-full max-w-lg flex-col rounded-t-2xl sm:rounded-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="border-b border-gray-100 px-5 py-4">
+          <h2 className="text-foreground text-lg font-bold">{t.recipeEditIngredient}</h2>
+          {loadState.status === "ready" && loadState.data.subtitle && (
+            <p className="text-text-muted mt-1 text-sm">{loadState.data.subtitle}</p>
+          )}
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5">
+          {loadState.status === "loading" && (
+            <p className="text-text-muted py-8 text-center text-sm">…</p>
+          )}
+          {loadState.status === "error" && (
+            <p className="py-8 text-center text-sm text-red-600">{loadState.message}</p>
+          )}
+          {loadState.status === "ready" &&
+            loadState.data.groups.map((group) => (
+              <section key={group.title} className="py-3">
+                <h3 className="text-text-muted mb-2 text-sm font-medium">{group.title}</h3>
+                <div className="divide-y divide-gray-100">
+                  {group.alternatives.map((alternative) => (
+                    <AlternativeRow
+                      key={alternative.id}
+                      alternative={alternative}
+                      countryCode={countryCode}
+                      count={quantities[alternative.id] ?? 0}
+                      unavailableLabel={t.recipeEditUnavailable}
+                      onSelect={() => select(alternative)}
+                      onIncrement={() => setCount(alternative.id, 1)}
+                      onDecrement={() => setCount(alternative.id, -1)}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+        </div>
+
+        <div className="border-t border-gray-100 px-5 py-4">
+          {saveError && <p className="mb-2 text-center text-sm text-red-600">{saveError}</p>}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-xl border border-gray-300 px-4 py-3 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              {t.recipeEditCancel}
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || loadState.status !== "ready"}
+              className="bg-picnic-red focus:ring-picnic-red flex-1 rounded-xl px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-60"
+            >
+              {saving ? t.recipeEditSaving : t.recipeEditSave}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type AlternativeRowProps = {
+  alternative: IngredientAlternative;
+  countryCode: CountryCode;
+  count: number;
+  unavailableLabel: string;
+  onSelect: () => void;
+  onIncrement: () => void;
+  onDecrement: () => void;
+};
+
+function AlternativeRow({
+  alternative,
+  countryCode,
+  count,
+  unavailableLabel,
+  onSelect,
+  onIncrement,
+  onDecrement,
+}: AlternativeRowProps) {
+  const [imgSrc, setImgSrc] = useState(
+    alternative.imageId ? buildImageUrl(alternative.imageId, countryCode) : PLACEHOLDER
+  );
+  const onSale = alternative.originalPrice !== null;
+  const selected = count > 0;
+
+  return (
+    <div
+      className={`flex items-center gap-3 py-3 ${onSale ? "-mx-2 rounded-lg bg-yellow-50 px-2" : ""} ${
+        alternative.isUnavailable ? "opacity-60" : ""
+      }`}
+    >
+      <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-lg bg-gray-50">
+        <Image
+          src={imgSrc}
+          alt={alternative.name}
+          fill
+          unoptimized
+          className="object-contain p-1"
+          onError={() => {
+            if (imgSrc !== PLACEHOLDER) setImgSrc(PLACEHOLDER);
+          }}
+        />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="text-text-dark truncate text-sm font-medium">{alternative.name}</p>
+        {alternative.brand && <p className="text-text-muted text-xs">{alternative.brand}</p>}
+        {alternative.isUnavailable ? (
+          <p className="text-xs text-red-600">
+            {alternative.unavailableReason ?? unavailableLabel}
+          </p>
+        ) : (
+          <p className="text-sm">
+            <span className={onSale ? "font-medium text-amber-600" : "text-text-dark font-medium"}>
+              {formatEuroPrice(alternative.displayPrice)}
+            </span>
+            {alternative.originalPrice !== null && (
+              <span className="ml-1.5 text-xs text-gray-400 line-through">
+                {formatEuroPrice(alternative.originalPrice)}
+              </span>
+            )}
+          </p>
+        )}
+        <p className="text-text-muted text-xs">
+          {[alternative.unitQuantity, ...alternative.tags].filter(Boolean).join(" · ")}
+        </p>
+      </div>
+
+      {selected ? (
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={onDecrement}
+            aria-label="-"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-300 text-sm"
+          >
+            −
+          </button>
+          <span className="text-foreground w-4 text-center text-sm font-medium">{count}</span>
+          <button
+            type="button"
+            onClick={onIncrement}
+            aria-label="+"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-300 text-sm"
+          >
+            +
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          role="radio"
+          aria-checked={false}
+          disabled={alternative.isUnavailable}
+          onClick={onSelect}
+          className="h-6 w-6 shrink-0 rounded-full border-2 border-gray-300 disabled:opacity-40"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/recipe/recipe-ingredient-row.tsx
+++ b/src/components/recipe/recipe-ingredient-row.tsx
@@ -136,15 +136,10 @@ export function RecipeIngredientRow({
           type="button"
           onClick={onEdit}
           aria-label={ingredient.name}
-          className="text-text-muted hover:text-foreground ml-2 shrink-0 p-1 transition-colors"
+          className="hover:text-foreground ml-2 shrink-0 rounded-full p-1.5 text-gray-600 transition-colors hover:bg-gray-100"
         >
-          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-            <path
-              d="M4 20h4L18.5 9.5a2.1 2.1 0 0 0-3-3L5 17v3z"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
+          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M21.731 2.269a2.625 2.625 0 0 0-3.712 0l-1.157 1.157 3.712 3.712 1.157-1.157a2.625 2.625 0 0 0 0-3.712ZM19.513 8.199l-3.712-3.712-12.15 12.15a5.25 5.25 0 0 0-1.32 2.214l-.8 2.685a.75.75 0 0 0 .933.933l2.685-.8a5.25 5.25 0 0 0 2.214-1.32L19.513 8.2Z" />
           </svg>
         </button>
       )}

--- a/src/components/recipe/recipe-ingredient-row.tsx
+++ b/src/components/recipe/recipe-ingredient-row.tsx
@@ -29,6 +29,8 @@ type RecipeIngredientRowProps = {
   basePortion: number;
   checked: boolean;
   onToggle: () => void;
+  /** Opens the ingredient editor; omitted when the ingredient has no component id. */
+  onEdit?: () => void;
 };
 
 export function RecipeIngredientRow({
@@ -38,6 +40,7 @@ export function RecipeIngredientRow({
   basePortion,
   checked,
   onToggle,
+  onEdit,
 }: RecipeIngredientRowProps) {
   const countryCode = useCountryCode();
   const [imgSrc, setImgSrc] = useState(
@@ -128,6 +131,23 @@ export function RecipeIngredientRow({
           </p>
         )}
       </div>
+      {onEdit && (
+        <button
+          type="button"
+          onClick={onEdit}
+          aria-label={ingredient.name}
+          className="text-text-muted hover:text-foreground ml-2 shrink-0 p-1 transition-colors"
+        >
+          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path
+              d="M4 20h4L18.5 9.5a2.1 2.1 0 0 0-3-3L5 17v3z"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }

--- a/src/lib/core/i18n/de.ts
+++ b/src/lib/core/i18n/de.ts
@@ -211,6 +211,13 @@ export const de = {
   recipePriceTotal: "gesamt",
   recipeAllergens: "Enthält",
   recipeMayContain: "Kann enthalten",
+  recipeEditIngredient: "Zutat anpassen",
+  recipeEditSave: "Speichern",
+  recipeEditSaving: "Wird gespeichert...",
+  recipeEditCancel: "Abbrechen",
+  recipeEditLoadError: "Alternativen konnten nicht geladen werden.",
+  recipeEditSaveError: "Zutat konnte nicht angepasst werden.",
+  recipeEditUnavailable: "Produkt nicht mehr lieferbar",
   recipeNutrition: "Nährwerte",
 
   // Toast / error view

--- a/src/lib/core/i18n/fr.ts
+++ b/src/lib/core/i18n/fr.ts
@@ -211,6 +211,13 @@ export const fr = {
   recipePriceTotal: "total",
   recipeAllergens: "Contient",
   recipeMayContain: "Peut contenir",
+  recipeEditIngredient: "Modifier l'ingrédient",
+  recipeEditSave: "Enregistrer",
+  recipeEditSaving: "Enregistrement...",
+  recipeEditCancel: "Annuler",
+  recipeEditLoadError: "Impossible de charger les alternatives.",
+  recipeEditSaveError: "Impossible de modifier l'ingrédient.",
+  recipeEditUnavailable: "Produit plus disponible",
   recipeNutrition: "Valeurs nutritionnelles",
 
   // Toast / error view

--- a/src/lib/core/i18n/nl.ts
+++ b/src/lib/core/i18n/nl.ts
@@ -214,6 +214,13 @@ export const nl = {
   recipePriceTotal: "totaal",
   recipeAllergens: "Bevat",
   recipeMayContain: "Kan bevatten",
+  recipeEditIngredient: "Ingrediënt aanpassen",
+  recipeEditSave: "Opslaan",
+  recipeEditSaving: "Opslaan...",
+  recipeEditCancel: "Annuleren",
+  recipeEditLoadError: "Alternatieven konden niet worden geladen.",
+  recipeEditSaveError: "Ingrediënt kon niet worden aangepast.",
+  recipeEditUnavailable: "Niet meer leverbaar",
   recipeNutrition: "Voedingswaarde",
 
   // Toast / error view

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -537,6 +537,44 @@ export type RecipeDetail = {
 
 export type RecipeDetailApiResponse = RecipeDetail;
 
+export type IngredientAlternative = {
+  /** selling_unit_id */
+  id: string;
+  name: string;
+  brand: string | null;
+  imageId: string | null;
+  /** Price in cents; 0 when the product is unavailable and shows no price */
+  displayPrice: number;
+  /** Strikethrough price in cents, or null when not discounted */
+  originalPrice: number | null;
+  /** Promotion badge text, e.g. "jetzt 2.29€" */
+  promotionLabel: string | null;
+  /** Package size as shown on the tile, e.g. "500g" */
+  unitQuantity: string;
+  /** Trailing tile labels such as "Vegan" or "Tiefkühl" */
+  tags: string[];
+  isUnavailable: boolean;
+  /** Reason text shown instead of a price, e.g. "Produkt nicht mehr lieferbar" */
+  unavailableReason: string | null;
+};
+
+export type IngredientAlternativeGroup = {
+  title: string;
+  alternatives: IngredientAlternative[];
+};
+
+export type IngredientEditData = {
+  ingredientId: string;
+  /** e.g. "125 g nach dem Originalrezept"; empty when the page omits it */
+  subtitle: string;
+  /** First group is the ingredient's own variants; later groups are suggestions */
+  groups: IngredientAlternativeGroup[];
+  /** selling_unit_id -> quantity, as currently saved on the account */
+  selected: Record<string, number>;
+};
+
+export type IngredientEditApiResponse = IngredientEditData;
+
 /** Recipe IDs the user has saved on their Picnic account. */
 export type SavedRecipesApiResponse = {
   recipeIds: string[];

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -492,6 +492,8 @@ export type CookbookApiResponse = {
 export type RecipeIngredient = {
   /** selling_unit_id — used for cart mutations */
   id: string;
+  /** selling_group_component_id — identifies the ingredient slot, not the product */
+  ingredientId: string | null;
   name: string;
   imageId: string | null;
   /** Price in cents */

--- a/src/lib/recipe/parse-ingredient-edit.ts
+++ b/src/lib/recipe/parse-ingredient-edit.ts
@@ -1,0 +1,189 @@
+import type {
+  IngredientAlternative,
+  IngredientAlternativeGroup,
+  IngredientEditData,
+} from "@/lib/core/types";
+import { cleanMarkdown, collectMarkdowns, findNodeById } from "@/lib/pml/pml-helpers";
+
+type PmlRecord = Record<string, unknown>;
+
+const GROUP_ID_PREFIX = "editable-selling-unit-list-";
+const SUBHEADER_ID_PREFIX = "editable-selling-unit-list-subheader-";
+const TILE_ID_RE = /^core_selling_unit_(s\d+)_stepper_state$/;
+const PRICE_RE = /^\d+[.,]\d{2}$/;
+const QUANTITY_RE =
+  /^\d+(?:[.,]\d+)?\s*(?:x\s*\d+(?:[.,]\d+)?\s*)?(?:g|kg|ml|cl|l|st|stk|stuks?|st[üu]ck|pack)\.?$/i;
+/** Every tile repeats the same page background image before the product image. */
+const BACKGROUND_IMAGE_PREFIX = "picnic-page/";
+/** A real name has at least two letters; this rejects "300g" and bare numbers. */
+const HAS_WORD_RE = /\p{L}{2}/u;
+
+/** Collect every node in the tree matching a predicate, outermost first. */
+function collectNodes(obj: unknown, match: (node: PmlRecord) => boolean): PmlRecord[] {
+  const found: PmlRecord[] = [];
+  const walk = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) walk(item);
+      return;
+    }
+    if (typeof value !== "object" || value === null) return;
+    const record = value as PmlRecord;
+    if (match(record)) {
+      found.push(record);
+      return;
+    }
+    for (const child of Object.values(record)) walk(child);
+  };
+  walk(obj);
+  return found;
+}
+
+/** The product image is the first IMAGE that is not the shared page background. */
+function extractProductImageId(node: unknown): string | null {
+  const images = collectNodes(node, (n) => n.type === "IMAGE");
+  for (const image of images) {
+    const source = (image.source ?? image.fallbackSource) as { id?: string } | undefined;
+    const id = source?.id;
+    if (typeof id === "string" && !id.startsWith(BACKGROUND_IMAGE_PREFIX)) return id;
+  }
+  return null;
+}
+
+type PromotionData = {
+  price?: number;
+  strikethrough_price?: number;
+  promotion_label?: string;
+  show_strikethrough_price?: boolean;
+};
+
+/** Read the promotion analytics context, which carries exact cent amounts. */
+function extractPromotion(node: unknown): PromotionData | null {
+  const carriers = collectNodes(
+    node,
+    (n) => typeof n.analytics === "object" && n.analytics !== null
+  );
+  for (const carrier of carriers) {
+    const contexts = (carrier.analytics as { contexts?: unknown[] }).contexts ?? [];
+    for (const context of contexts) {
+      if (typeof context !== "object" || context === null) continue;
+      const entry = context as PmlRecord;
+      if (typeof entry.schema === "string" && entry.schema.includes("/promotion/")) {
+        return (entry.data as PromotionData | undefined) ?? null;
+      }
+    }
+  }
+  return null;
+}
+
+function toCents(text: string): number {
+  return Math.round(parseFloat(text.replace(",", ".")) * 100);
+}
+
+function parseTile(node: PmlRecord, sellingUnitId: string): IngredientAlternative {
+  const lines = collectMarkdowns(node)
+    .map((md) => cleanMarkdown(md).trim())
+    .filter(Boolean);
+
+  const promotion = extractPromotion(node);
+  const promotionLabel = promotion?.promotion_label ?? null;
+
+  // The brand always follows the chevron row; unavailable tiles have neither.
+  const chevronIndex = lines.indexOf(">");
+  const brand = chevronIndex >= 0 ? (lines[chevronIndex + 1] ?? null) : null;
+
+  const prices = lines.filter((line) => PRICE_RE.test(line));
+  const displayPrice = promotion?.price ?? (prices[0] ? toCents(prices[0]) : 0);
+  const strikethrough = promotion?.strikethrough_price ?? (prices[1] ? toCents(prices[1]) : null);
+  // Only treat it as a discount when it is actually higher than what you pay.
+  const originalPrice =
+    strikethrough !== null && strikethrough !== undefined && strikethrough > displayPrice
+      ? strikethrough
+      : null;
+
+  const quantityIndex = lines.findIndex((line) => QUANTITY_RE.test(line));
+  const unitQuantity = quantityIndex >= 0 ? lines[quantityIndex] : "";
+
+  const name =
+    lines.find(
+      (line) =>
+        line !== ">" &&
+        line !== brand &&
+        line !== promotionLabel &&
+        !PRICE_RE.test(line) &&
+        !QUANTITY_RE.test(line) &&
+        HAS_WORD_RE.test(line)
+    ) ?? "";
+
+  // An unavailable tile shows a reason where the price would be.
+  const isUnavailable = prices.length === 0 && promotion?.price === undefined;
+  const trailing =
+    quantityIndex >= 0
+      ? lines.slice(quantityIndex + 1).filter((line) => HAS_WORD_RE.test(line) && line !== name)
+      : [];
+
+  return {
+    id: sellingUnitId,
+    name,
+    brand,
+    imageId: extractProductImageId(node),
+    displayPrice,
+    originalPrice,
+    promotionLabel,
+    unitQuantity,
+    tags: isUnavailable ? [] : trailing,
+    isUnavailable,
+    unavailableReason: isUnavailable ? (trailing[0] ?? null) : null,
+  };
+}
+
+/** Read the saved selection off the page's root state boundary. */
+function extractSelected(rawPage: unknown): Record<string, number> {
+  const boundaries = collectNodes(rawPage, (n) => n.id === "SellingGroupComponentEditingRootState");
+  const state = boundaries[0]?.state as
+    | { originallySelectedSellingUnits?: Record<string, number> }
+    | undefined;
+  return state?.originallySelectedSellingUnits ?? {};
+}
+
+/**
+ * Parse a selling-group-component-edit-page Fusion page into typed alternatives.
+ *
+ * Groups are BLOCKs whose id starts with `editable-selling-unit-list-`; the group
+ * title is the id suffix. Each alternative sits under a node whose id encodes its
+ * selling unit id.
+ *
+ * The page's own `unavailableSellingUnitIds` is deliberately ignored: it comes
+ * back empty even on pages that render "Produkt nicht mehr lieferbar", so
+ * availability is read off each tile instead.
+ */
+export function parseIngredientEdit(rawPage: unknown, ingredientId: string): IngredientEditData {
+  const header = findNodeById(rawPage, "ingredient-editing-header");
+  const headerLines = header
+    ? collectMarkdowns(header)
+        .map((md) => cleanMarkdown(md).trim())
+        .filter(Boolean)
+    : [];
+  // Line 0 is the page title ("Zutat anpassen"), which the UI supplies itself.
+  const subtitle = headerLines[1] ?? "";
+
+  const groupNodes = collectNodes(
+    rawPage,
+    (n) =>
+      typeof n.id === "string" &&
+      n.id.startsWith(GROUP_ID_PREFIX) &&
+      !n.id.startsWith(SUBHEADER_ID_PREFIX)
+  );
+
+  const groups: IngredientAlternativeGroup[] = [];
+  for (const groupNode of groupNodes) {
+    const title = (groupNode.id as string).slice(GROUP_ID_PREFIX.length);
+    const tiles = collectNodes(groupNode, (n) => typeof n.id === "string" && TILE_ID_RE.test(n.id));
+    const alternatives = tiles.map((tile) => {
+      const match = TILE_ID_RE.exec(tile.id as string);
+      return parseTile(tile, match ? match[1] : "");
+    });
+    if (alternatives.length > 0) groups.push({ title, alternatives });
+  }
+
+  return { ingredientId, subtitle, groups, selected: extractSelected(rawPage) };
+}

--- a/src/lib/recipe/parse-recipe-detail.ts
+++ b/src/lib/recipe/parse-recipe-detail.ts
@@ -489,6 +489,7 @@ export function parseRecipeDetail(rawPage: unknown, recipeId: string): RecipeDet
     const displayName = tileNameByUnitId.get(unit.selling_unit_id) ?? tile?.name ?? "";
     ingredients.push({
       id: unit.selling_unit_id,
+      ingredientId: unit.ingredient_id ?? null,
       name: displayName,
       imageId: tile?.imageId ?? null,
       displayPrice: tile?.displayPrice ?? 0,


### PR DESCRIPTION
## Edit recipe ingredients from the recipe page

Adds the app's ingredient editing screen ("Zutat anpassen") to the web recipe page, and fixes a cart bug that made the app's own version of that screen fail to open.

### The bug

Ingredients added from the web could not be edited in the phone app: tapping the pencil did nothing.

`add-to-cart` sent only a partial `SELLING_GROUP` context, missing `MEAL_PLAN` and `selling_group_component_id`. The app derives the portion count from `MEAL_PLAN.numberOfServings`, falls back to `0`, and opens the edit page with `portions=0`, this let Picnic fails to render server-side (`portions=4` returns 200, `portions=0` and a missing `portions` both error). Sending both contexts fixes it.

### The feature

Each ingredient row gets a edit button opening a modal with every alternative selling unit Picnic offers, in Picnic's own grouping. Discounted alternatives show the strikethrough price and are highlighted, in this list you can see which substitutes are on promotion, which the web had no way of showing. Saving writes back to Picnic, so the app and the web stay in sync.

```
GET  /pages/selling-group-component-edit-page?ingredient_id=…&selling_group_id=…&portions=…
POST /pages/task/save-selling-group-edit-task      -> { shouldUpdateCart }
POST /pages/task/assign-sellable-component-to-day                (when shouldUpdateCart)
POST /pages/task/delete-selling-group-component                  (all units deselected)
```

`swapType` follows the app's rule (own variants → `WITHIN_SELLING_GROUP_COMPONENT`, suggestions → `POPULAR_SELECTION`); the route re-reads the page server-side to classify rather than trusting the client. The `swapType` / `component_swap_type` casing mismatch between the two payloads is what the app sends, not a typo.

Two things worth knowing for anyone parsing this page: `unavailableSellingUnitIds` comes back `[]` even when a tile renders "Produkt nicht mehr lieferbar" (availability is read off the tile instead), and every tile's first image is a shared `picnic-page/…` background rather than the product.

### Testing

**Only tested on a DE account.** The parser avoids language-specific strings, but I have no NL account to confirm against.