### PR TITLE
fix(recipe): ingredient editor follow-ups

### DIFF
--- a/src/components/recipe/ingredient-edit-modal.tsx
+++ b/src/components/recipe/ingredient-edit-modal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import Image from "next/image";
 
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { useCountryCode, useTranslations } from "@/contexts/country-context";
 import { TOKEN_EXPIRED_REDIRECT } from "@/lib/core/constants";
 import { formatEuroPrice } from "@/lib/core/format-price";
@@ -72,17 +73,26 @@ export function IngredientEditModal({
     return () => controller.abort();
   }, [recipeId, ingredientId, portions, t.recipeEditLoadError]);
 
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
   const select = useCallback((alternative: IngredientAlternative) => {
     if (alternative.isUnavailable) return;
     // Picking a different product replaces the selection, as the app does.
-    setQuantities((prev) => (prev[alternative.id] ? {} : { [alternative.id]: 1 }));
+    setQuantities({ [alternative.id]: 1 });
   }, []);
 
   const setCount = useCallback((id: string, delta: number) => {
     setQuantities((prev) => {
-      const next = Math.max(0, (prev[id] ?? 0) + delta);
-      if (next === 0) return {};
-      return { [id]: next };
+      // Only touch this unit: a saved selection can hold several units at once.
+      const { [id]: current = 0, ...rest } = prev;
+      const next = Math.max(0, current + delta);
+      return next === 0 ? rest : { ...rest, [id]: next };
     });
   }, []);
 
@@ -117,20 +127,23 @@ export function IngredientEditModal({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ingredient-edit-title"
         className="bg-card-bg flex max-h-[90vh] w-full max-w-lg flex-col rounded-t-2xl sm:rounded-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="border-b border-gray-100 px-5 py-4">
-          <h2 className="text-foreground text-lg font-bold">{t.recipeEditIngredient}</h2>
+          <h2 id="ingredient-edit-title" className="text-foreground text-lg font-bold">
+            {t.recipeEditIngredient}
+          </h2>
           {loadState.status === "ready" && loadState.data.subtitle && (
             <p className="text-text-muted mt-1 text-sm">{loadState.data.subtitle}</p>
           )}
         </div>
 
         <div className="flex-1 overflow-y-auto px-5">
-          {loadState.status === "loading" && (
-            <p className="text-text-muted py-8 text-center text-sm">…</p>
-          )}
+          {loadState.status === "loading" && <LoadingSpinner />}
           {loadState.status === "error" && (
             <p className="py-8 text-center text-sm text-red-600">{loadState.message}</p>
           )}
@@ -146,6 +159,8 @@ export function IngredientEditModal({
                       countryCode={countryCode}
                       count={quantities[alternative.id] ?? 0}
                       unavailableLabel={t.recipeEditUnavailable}
+                      addLabel={t.addOneAriaLabel}
+                      removeLabel={t.removeOneAriaLabel}
                       onSelect={() => select(alternative)}
                       onIncrement={() => setCount(alternative.id, 1)}
                       onDecrement={() => setCount(alternative.id, -1)}
@@ -186,6 +201,8 @@ type AlternativeRowProps = {
   countryCode: CountryCode;
   count: number;
   unavailableLabel: string;
+  addLabel: string;
+  removeLabel: string;
   onSelect: () => void;
   onIncrement: () => void;
   onDecrement: () => void;
@@ -196,6 +213,8 @@ function AlternativeRow({
   countryCode,
   count,
   unavailableLabel,
+  addLabel,
+  removeLabel,
   onSelect,
   onIncrement,
   onDecrement,
@@ -254,7 +273,7 @@ function AlternativeRow({
           <button
             type="button"
             onClick={onDecrement}
-            aria-label="-"
+            aria-label={removeLabel}
             className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-300 text-sm"
           >
             −
@@ -263,7 +282,7 @@ function AlternativeRow({
           <button
             type="button"
             onClick={onIncrement}
-            aria-label="+"
+            aria-label={addLabel}
             className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-gray-300 text-sm"
           >
             +
@@ -274,6 +293,7 @@ function AlternativeRow({
           type="button"
           role="radio"
           aria-checked={false}
+          aria-label={alternative.name}
           disabled={alternative.isUnavailable}
           onClick={onSelect}
           className="h-6 w-6 shrink-0 rounded-full border-2 border-gray-300 disabled:opacity-40"

--- a/src/components/recipe/recipe-ingredient-row.tsx
+++ b/src/components/recipe/recipe-ingredient-row.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 
-import { useCountryCode } from "@/contexts/country-context";
+import { useCountryCode, useTranslations } from "@/contexts/country-context";
 import { formatEuroPrice } from "@/lib/core/format-price";
 import { buildImageUrl } from "@/lib/core/image-url";
 import type { RecipeIngredient } from "@/lib/core/types";
@@ -43,6 +43,7 @@ export function RecipeIngredientRow({
   onEdit,
 }: RecipeIngredientRowProps) {
   const countryCode = useCountryCode();
+  const t = useTranslations();
   const [imgSrc, setImgSrc] = useState(
     ingredient.imageId ? buildImageUrl(ingredient.imageId, countryCode) : PLACEHOLDER
   );
@@ -135,7 +136,7 @@ export function RecipeIngredientRow({
         <button
           type="button"
           onClick={onEdit}
-          aria-label={ingredient.name}
+          aria-label={`${t.recipeEditIngredient}: ${ingredient.name}`}
           className="hover:text-foreground ml-2 shrink-0 rounded-full p-1.5 text-gray-600 transition-colors hover:bg-gray-100"
         >
           <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">

--- a/src/lib/recipe/parse-ingredient-edit.ts
+++ b/src/lib/recipe/parse-ingredient-edit.ts
@@ -11,8 +11,9 @@ const GROUP_ID_PREFIX = "editable-selling-unit-list-";
 const SUBHEADER_ID_PREFIX = "editable-selling-unit-list-subheader-";
 const TILE_ID_RE = /^core_selling_unit_(s\d+)_stepper_state$/;
 const PRICE_RE = /^\d+[.,]\d{2}$/;
+/** Package size line, e.g. "500 g", "400 gram", "1 kilo", "6 stuks", "2 pièces". */
 const QUANTITY_RE =
-  /^\d+(?:[.,]\d+)?\s*(?:x\s*\d+(?:[.,]\d+)?\s*)?(?:g|kg|ml|cl|l|st|stk|stuks?|st[üu]ck|pack)\.?$/i;
+  /^\d+(?:[.,]\d+)?\s*(?:x\s*\d+(?:[.,]\d+)?\s*)?(?:g|gram|kg|kilo|ml|milliliter|cl|l|liter|litre|st|stk|stuks?|st[üu]ck|pi[eè]ces?|pcs?|pack|pak)\.?$/i;
 /** Every tile repeats the same page background image before the product image. */
 const BACKGROUND_IMAGE_PREFIX = "picnic-page/";
 /** A real name has at least two letters; this rejects "300g" and bare numbers. */
@@ -100,7 +101,16 @@ function parseTile(node: PmlRecord, sellingUnitId: string): IngredientAlternativ
       ? strikethrough
       : null;
 
-  const quantityIndex = lines.findIndex((line) => QUANTITY_RE.test(line));
+  // Unit words differ per country ("400 gram" on NL, "500 g" on DE), so fall back
+  // to position: the size always follows the price block.
+  const lastPriceIndex = lines.reduce(
+    (last, line, index) => (PRICE_RE.test(line) ? index : last),
+    -1
+  );
+  const afterPriceIndex = lastPriceIndex >= 0 ? lastPriceIndex + 1 : -1;
+  const matchedIndex = lines.findIndex((line) => QUANTITY_RE.test(line));
+  const quantityIndex =
+    matchedIndex >= 0 ? matchedIndex : afterPriceIndex < lines.length ? afterPriceIndex : -1;
   const unitQuantity = quantityIndex >= 0 ? lines[quantityIndex] : "";
 
   const name =


### PR DESCRIPTION
Follow-ups from reviewing and live-testing #47 on an NL account.

## Bug: package size missing on NL (and FR)

The quantity regex in `parse-ingredient-edit.ts` only accepted short units (`g`, `kg`, `ml`, `stuks`, `Stück`, `pack`). Picnic NL renders sizes as full words, so every alternative came back with an empty `unitQuantity` and the modal showed no size line:

```
["Zilvervliesrijst", ">", "Picnic", "0.79", "400 gram"]
["Zilvervliesrijst", ">", "Picnic", "1.39", "1 kilo"]
```

Fix: extend the regex with full-word NL/DE/FR units and, when nothing matches, fall back to the line directly after the price block, which is where the size sits.

## Modal fixes

- **Multi-unit state**: the server path already handles a saved selection with more than one unit, but `setCount` collapsed the state to a single id, so stepping one unit dropped the others. It now only touches the unit being stepped. Picking a different product still replaces the selection, as the app does.
- **Dialog semantics**: `role="dialog"`, `aria-modal`, `aria-labelledby` on the panel, and Escape closes the modal.
- **Labels**: stepper buttons use `t.addOneAriaLabel` / `t.removeOneAriaLabel` like `quantity-stepper.tsx`, the radio is labelled with the product name, and the pencil reads "Ingrediënt aanpassen: <name>" instead of the bare ingredient name.
- **Loading state**: reuse `LoadingSpinner` instead of a literal "…".
- Removed the unreachable "clear when already selected" branch in `select` (the radio is only rendered when the count is 0).

## Testing

Verified on an NL account: sizes render (`400 gram`, `1 kilo`, `375 gram`), the accessibility tree shows the dialog and the translated stepper labels, Escape closes the modal, and saving a different unit and switching back still works. `npm run lint`, `tsc --noEmit`, and Prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
