### PR TITLE
fix(cookbook): open recipes in the same tab

### DIFF
--- a/src/components/recipe/recipe-card.tsx
+++ b/src/components/recipe/recipe-card.tsx
@@ -29,10 +29,7 @@ export function RecipeCard({ recipe }: RecipeCardProps) {
     <div className="border-card-border bg-card-bg relative flex flex-col overflow-hidden rounded-lg border shadow-sm transition-shadow hover:shadow-md">
       <FavoriteButton recipeId={recipe.id} className="absolute top-2 right-2 z-10" />
 
-      <Link
-        href={`/recipe/${recipe.id}`}
-        className="flex flex-1 flex-col"
-      >
+      <Link href={`/recipe/${recipe.id}`} className="flex flex-1 flex-col">
         <div className="relative h-40 w-full bg-gray-50">
           <Image
             src={imageSrc}

--- a/src/components/recipe/recipe-card.tsx
+++ b/src/components/recipe/recipe-card.tsx
@@ -31,8 +31,6 @@ export function RecipeCard({ recipe }: RecipeCardProps) {
 
       <Link
         href={`/recipe/${recipe.id}`}
-        target="_blank"
-        rel="noopener noreferrer"
         className="flex flex-1 flex-col"
       >
         <div className="relative h-40 w-full bg-gray-50">


### PR DESCRIPTION
Recipe cards in the cookbook linked with `target="_blank"`, so clicking a recipe opened it in a new browser tab. Internal navigation should stay in the current tab like every other link in the app, so this drops the `target` and the now-unneeded `rel`.

Not touched: the ingredient rows on the recipe page also open the product page in a new tab (`recipe-ingredient-row.tsx`). That one may be intentional to keep the checked-ingredient state, so I left it for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
